### PR TITLE
FSM join

### DIFF
--- a/common/fsm_join_add_cdscdnskeys.go
+++ b/common/fsm_join_add_cdscdnskeys.go
@@ -1,0 +1,10 @@
+package music
+
+var FsmJoinAddCdscdnskeys = FSMTransition{
+    Description: "Once all DNSKEYs are present in all signers (criteria), build CDS/CDNSKEYs RRset and push to all signers (action)",
+    Criteria:    func(z *Zone) bool { return true },
+    Action: func(z *Zone) bool {
+        z.StateTransition(FsmStateSyncDnskeys, FsmStateAddCdscdnskeys)
+        return true
+    },
+}

--- a/common/fsm_join_add_csync.go
+++ b/common/fsm_join_add_csync.go
@@ -1,0 +1,10 @@
+package music
+
+var FsmJoinAddCsync = FSMTransition{
+    Description: "Once all NS are present in all signers (criteria), build CSYNC record and push to all signers (action)",
+    Criteria:    func(z *Zone) bool { return true },
+    Action: func(z *Zone) bool {
+        z.StateTransition(FsmStateWaitDs, FsmStateAddCsync)
+        return true
+    },
+}

--- a/common/fsm_join_parent_ds_synced.go
+++ b/common/fsm_join_parent_ds_synced.go
@@ -1,0 +1,10 @@
+package music
+
+var FsmJoinParentDsSynced = FSMTransition{
+    Description: "Wait for parent to pick up CDS/CDNSKEYs and update it's DS (criteria), then remove CDS/CDNSKEYs from all signers (action)",
+    Criteria:    func(z *Zone) bool { return true },
+    Action: func(z *Zone) bool {
+        z.StateTransition(FsmStateAddCdscdnskeys, FsmStateParentDsSynced)
+        return true
+    },
+}

--- a/common/fsm_join_parent_ns_synced.go
+++ b/common/fsm_join_parent_ns_synced.go
@@ -1,0 +1,10 @@
+package music
+
+var FsmJoinParentNsSynced = FSMTransition{
+    Description: "Wait for parent to pick up CSYNC and update it's NS records (criteria), then remove CSYNC from all signers and STOP (action)",
+    Criteria:    func(z *Zone) bool { return true },
+    Action: func(z *Zone) bool {
+        z.StateTransition(FsmStateAddCsync, FsmStateParentNsSynced)
+        return true
+    },
+}

--- a/common/fsm_join_sync_dnskeys.go
+++ b/common/fsm_join_sync_dnskeys.go
@@ -1,0 +1,10 @@
+package music
+
+var FsmJoinSyncDnskeys = FSMTransition{
+    Description: "First step when joining, this transistion has no criteria and will sync DNSKEYs between all signers (action)",
+    Criteria:    func(z *Zone) bool { return true },
+    Action: func(z *Zone) bool {
+        z.StateTransition(FsmStateSignerUnsynced, FsmStateSyncDnskeys)
+        return true
+    },
+}

--- a/common/fsm_join_wait_ds.go
+++ b/common/fsm_join_wait_ds.go
@@ -1,0 +1,10 @@
+package music
+
+var FsmJoinWaitDs = FSMTransition{
+    Description: "Wait enough time for parent DS records to propagate (criteria), then sync NS records between all signers (action)",
+    Criteria:    func(z *Zone) bool { return true },
+    Action: func(z *Zone) bool {
+        z.StateTransition(FsmStateParentDsSynced, FsmStateWaitDs)
+        return true
+    },
+}

--- a/common/signerops.go
+++ b/common/signerops.go
@@ -183,7 +183,7 @@ func (mdb *MusicDB) SignerJoinGroup(s Signer, g string) (error, string) {
     }
 
     // if we now have more than one signer in the signer group it is possible that they
-    // are unsynched. Then we must enter the "add-signer" process to get them in sync.
+    // are unsynced. Then we must enter the "add-signer" process to get them in sync.
     if len(sg.SignerMap) > 1 {
         zones, err := mdb.GetSignerGroupZones(sg)
         if err != nil {

--- a/common/zoneops.go
+++ b/common/zoneops.go
@@ -84,7 +84,7 @@ func (z *Zone) StateTransition(from, to string) error {
         return errors.New(fmt.Sprintf("StateTransition: Error: zone %s is in state '%s'. Should be '%s'.\n", z.State, from))
     }
 
-    if from == "stop" && to == "stop" {
+    if from == FsmStateStop && to == FsmStateStop {
         fmt.Printf("StateTransition: terminal state reached. Exiting process.\n")
         to = "---"
         fsm = "---"
@@ -235,7 +235,7 @@ func (mdb *MusicDB) ZoneJoinGroup(zonename string, dbzone *Zone, exist bool, g s
             "Zone %s has joined signer group %s and started the process '%s'.", zonename, SignerJoinGroupProcess)
     }
     return nil, fmt.Sprintf(
-        `Zone %s has joined signer group %s but could not start the process '%s' 
+        `Zone %s has joined signer group %s but could not start the process '%s'
 as the zone is already in process '%s'. Problematic.`, zonename, SignerJoinGroupProcess, dbzone.FSM)
 }
 

--- a/music-cli/cmd/zone.go
+++ b/music-cli/cmd/zone.go
@@ -625,16 +625,13 @@ func PrintZones(zm map[string]music.Zone) {
             zone.ZskState = "---"
         }
 
-        var pnext string
+        nextStates := []string{}
         for k, _ := range zone.NextState {
-            pnext += " " + k
-        }
-        if len(pnext) > 1 {
-            pnext = pnext[1:]
+            nextStates = append(nextStates, k)
         }
         out = append(out, fmt.Sprintf("%s|%s|%s|%s|%s|[%s]|%s", zone.Name, group, fsm,
             zone.State, zone.Statestamp.Format("2006-01-02 15:04:05"),
-            pnext, zone.ZskState))
+            strings.Join(nextStates, " "), zone.ZskState))
     }
     fmt.Printf("%s\n", columnize.SimpleFormat(out))
 }


### PR DESCRIPTION
- Use const for FSM states (need to add more)
- Remove unused FSM structure members
- Add `FsmTransitionStopFactory` and `FsmGenericStop` step
- changes "synch" to "sync"
- Remove `Name` from FSMState as this already exists in all maps
- Rewrite join steps into fewer steps and follow logic done in multi-signer-controller