### PR TITLE
TLS fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ fmt:
 	gsed -i -e 's%	%    %g' `find common musicd music-cli -type f -name '*.go'`
 
 cert:
-	openssl req -x509 -nodes -new -sha256 -days 1024 -newkey rsa:2048 -keyout ${CERTDIR}/RootCA.key -out ${CERTDIR}/RootCA.pem -subj "/C=US/CN=Music-Root-CA"
-	openssl x509 -outform pem -in ${CERTDIR}/RootCA.pem -out ${CERTDIR}/RootCA.crt
-	openssl req -new -nodes -newkey rsa:2048 -keyout ${CERTDIR}/localhost.key -out ${CERTDIR}/localhost.csr -subj "/C=SE/ST=Confusion/L=Lost/O=Music-Certificates/CN=localhost.local"
-	openssl x509 -req -sha256 -days 1024  -in ${CERTDIR}/localhost.csr -CA ${CERTDIR}/RootCA.pem -CAkey ${CERTDIR}/RootCA.key -CAcreateserial -extfile domains.ext -out ${CERTDIR}/localhost.crt
+	mkdir -p "${CERTDIR}"
+	openssl req -x509 -nodes -new -sha256 -days 1024 -newkey rsa:2048 -keyout "${CERTDIR}/RootCA.key" -out "${CERTDIR}/RootCA.pem" -subj "/C=US/CN=Music-Root-CA"
+	openssl x509 -outform pem -in "${CERTDIR}/RootCA.pem" -out "${CERTDIR}/RootCA.crt"
+	openssl req -new -nodes -newkey rsa:2048 -keyout "${CERTDIR}/localhost.key" -out "${CERTDIR}/localhost.csr" -subj "/C=SE/ST=Confusion/L=Lost/O=Music-Certificates/CN=localhost.local"
+	openssl x509 -req -sha256 -days 1024 -in "${CERTDIR}/localhost.csr" -CA "${CERTDIR}/RootCA.pem" -CAkey "${CERTDIR}/RootCA.key" -CAcreateserial -extfile domains.ext -out "${CERTDIR}/localhost.crt"

--- a/music-cli/music-cli.yaml.sample
+++ b/music-cli/music-cli.yaml.sample
@@ -6,7 +6,7 @@ api:
    baseurl:	https://desec.io/api/v1
 
 musicd:
-   baseurl:	http://127.0.0.1:8080/api/v1
+   baseurl:	https://127.0.0.1:8080/api/v1
    apikey:	you-have-stolen-my-frotzblinger
    authmethod: X-API-Key
    rootCApem: ../etc/certs/rootCA.pem

--- a/musicd/musicd.yaml.sample
+++ b/musicd/musicd.yaml.sample
@@ -1,9 +1,8 @@
 apiserver:
    address:	127.0.0.1:8080
-   usetls:	false   
    apikey:	you-have-stolen-my-frotzblinger
-   certFile: ../etc/certs/localhost+2.pem
-   keyFile: ../etc/certs/localhost+2.pem
+   certFile: ../etc/certs/localhost.crt
+   keyFile: ../etc/certs/localhost.key
 
 signers:
    desec:


### PR DESCRIPTION
- Fix Makefile if you don't have cert dir already
- Fix example conf to get TLS working
- Remove musicd apiserver.usetls, not is use