### PR TITLE
* cleanup of fsm.go / fsm_spec.go overlap,

### DIFF
--- a/common/fsm.go
+++ b/common/fsm.go
@@ -4,22 +4,11 @@
 package music
 
 import (
-	"fmt"
-	"time"
-	// "github.com/DNSSEC-Provisioning/music/fsm"
+	// "fmt"
 )
 
 const (
-	FsmStateSignerUnsynced   = "signers-unsynced"
-	FsmStateDnskeysSynced    = "dnskeys-synced"
-	FsmStateCdscdnskeysAdded = "cdscdnskeys-added"
-	FsmStateParentDsSynced   = "parent-ds-synced"
-	FsmStateDsPropagated     = "ds-propagated"
-	FsmStateCsyncAdded       = "csync-added"
-	FsmStateParentNsSynced   = "parent-ns-synced"
-	FsmStateNsesSynced       = "nses-synced"
-	FsmStateNsPropagated     = "ns-propagated"
-	FsmStateStop             = "stop"
+ 	FsmStateStop             = "stop"		// XXX: Yes, we need to keep this in the music package
 )
 
 type FSMState struct {
@@ -49,39 +38,6 @@ type FSM struct {
 	States       map[string]FSMState
 }
 
-func FsmCriteriaFactory(from, to string) func(z *Zone) bool {
-	return func(z *Zone) bool {
-		PrintTransition(z, "CRITERIA", from, to)
-		return true
-	}
-}
-
-func FsmActionFactory(from, to string) func(z *Zone) bool {
-	return func(z *Zone) bool {
-		PrintTransition(z, "ACTION", from, to)
-		z.StateTransition(from, to)
-		return true
-	}
-}
-
-func FsmTransitionFactory(from, to string) FSMTransition {
-	return FSMTransition{
-		Criteria: FsmCriteriaFactory(from, to),
-		Action:   FsmActionFactory(from, to),
-	}
-}
-
-func PrintTransition(z *Zone, ttype, from, dest string) {
-	fmt.Printf("*** Executing transition %s for %s-->%s for zone %s\n",
-		ttype, from, dest, z.Name)
-}
-
-func PrintStateDuration(z *Zone, state string) {
-	dur := time.Now().Sub(z.Statestamp)
-	fmt.Printf("*** Zone %s has been in state '%s' since %s (%v)\n",
-		z.Name, state, z.Statestamp.Format(layout), dur)
-}
-
 // Generic stop transistion
 func FsmTransitionStopFactory(from string) FSMTransition {
 	return FSMTransition{
@@ -94,167 +50,4 @@ func FsmTransitionStopFactory(from string) FSMTransition {
 		},
 		PostCondition: func(z *Zone) bool { return true },
 	}
-}
-
-var FsmGenericStop = FsmTransitionStopFactory(FsmStateStop)
-
-// PROCESS: ADD-SIGNER
-// defined in fsm_join*.go
-
-// PROCESS: REMOVE-SIGNER
-var FSMT_RS_1 = FsmTransitionFactory(FsmStateSignerUnsynced, "ns-known")
-var FSMT_RS_2 = FsmTransitionFactory("ns-known", "ns-synced")
-var FSMT_RS_3 = FsmTransitionFactory("ns-synced", "csync-published")
-var FSMT_RS_3b = FsmTransitionFactory("ns-synced", "delegation-ns-synced")
-var FSMT_RS_4 = FsmTransitionFactory("csync-published", "delegation-ns-synced")
-var FSMT_RS_5 = FsmTransitionFactory("delegation-ns-synced", "delegation-ns-synced-2")
-var FSMT_RS_6 = FsmTransitionFactory("delegation-ns-synced-2", "delegation-ns-synced-3")
-var FSMT_RS_7 = FsmTransitionFactory("delegation-ns-synced-3", "cds-known")
-var FSMT_RS_8 = FsmTransitionFactory("cds-known", "cds-synced")
-var FSMT_RS_9 = FsmTransitionFactory("cds-synced", "zsk-synced")
-var FSMT_RS_10 = FsmTransitionFactory("zsk-synced", "ds-synced")
-var FSMT_RS_11 = FsmTransitionFactory("ds-synced", "signers-synced")
-var FSMT_RS_12 = FsmTransitionFactory("signers-synced", FsmStateStop) // terminator signal
-var FSMT_RS_13 = FSMTransition{
-	Desc:     "FSMT_RS_13",
-	Criteria: FsmCriteriaFactory(FsmStateStop, FsmStateStop),
-	Action: func(z *Zone) bool {
-		fmt.Printf("Enter ACTION for <stop, stop>. zone state: %s\n", z.State)
-		z.StateTransition(FsmStateStop, FsmStateStop)
-		fmt.Printf("FsmAction (stop): Exiting the remove-signer process seems to have gone well. Yay!\n")
-		return true
-	},
-}
-
-// PROCESS: ADD-ZONE (bogus process, only for testing)
-var FSMT_AZ_1 = FsmTransitionFactory("ready", "join-sync-cds")
-var FSMT_AZ_2 = FsmTransitionFactory("join-sync-cds", "join-cds-synced")
-var FSMT_AZ_3 = FsmTransitionFactory("join-cds-synced", "ready")
-var FSMT_AZ_3b = FsmTransitionFactory("join-cds-synced", "foobar")
-var FSMT_AZ_4 = FsmTransitionFactory("foobar", "ready")
-
-// PROCESS: ZSK-ROLLOVER
-var FSMT_ZR_1 = FsmTransitionFactory(FsmStateSignerUnsynced, "zsks-known")
-var FSMT_ZR_2 = FsmTransitionFactory("zsks-known", "zsks-synced")
-var FSMT_ZR_3 = FsmTransitionFactory("zsks-synced", "signers-synced")
-var FSMT_ZR_4 = FsmTransitionFactory("signers-synced", FsmStateStop)
-var FSMT_ZR_5 = FsmTransitionFactory(FsmStateStop, FsmStateStop)
-
-var xxxFSMlist = map[string]FSM{
-	// PROCESS: ADD-ZONE: This is a bogus process, only for testing.
-	"add-zone": FSM{
-		Type:         "single-run",
-		InitialState: "ready",
-		States: map[string]FSMState{
-			"ready": FSMState{
-				Next: map[string]FSMTransition{"join-sync-cds": FSMT_AZ_1},
-			},
-			"join-sync-cds": FSMState{
-				Next: map[string]FSMTransition{"join-cds-synced": FSMT_AZ_2},
-			},
-			"join-cds-synced": FSMState{
-				Next: map[string]FSMTransition{
-					"ready":  FSMT_AZ_3,
-					"foobar": FSMT_AZ_3b,
-				},
-			},
-			"foobar": FSMState{
-				Next: map[string]FSMTransition{"ready": FSMT_AZ_4},
-			},
-		},
-	},
-
-	// PROCESS: REMOVE-SIGNER: This is a real process, from the draft doc.
-	"remove-signer-old": FSM{
-		Type:         "single-run",
-		InitialState: FsmStateSignerUnsynced,
-		States: map[string]FSMState{
-			FsmStateSignerUnsynced: FSMState{
-				Next: map[string]FSMTransition{"ns-known": FSMT_RS_1},
-			},
-			"ns-known": FSMState{
-				Next: map[string]FSMTransition{"ns-synced": FSMT_RS_2},
-			},
-			"ns-synced": FSMState{
-				Next: map[string]FSMTransition{
-					"csync-published":      FSMT_RS_3,
-					"delegation-ns-synced": FSMT_RS_3b,
-				},
-			},
-			"csync-published": FSMState{
-				Next: map[string]FSMTransition{
-					"delegation-ns-synced": FSMT_RS_4,
-				},
-			},
-			"delegation-ns-synced": FSMState{
-				Next: map[string]FSMTransition{"delegation-ns-synced-2": FSMT_RS_5},
-			},
-			"delegation-ns-synced-2": FSMState{
-				Next: map[string]FSMTransition{"delegation-ns-synced-3": FSMT_RS_6},
-			},
-			"delegation-ns-synced-3": FSMState{
-				Next: map[string]FSMTransition{"cds-known": FSMT_RS_7},
-			},
-			"cds-known": FSMState{
-				Next: map[string]FSMTransition{"cds-synced": FSMT_RS_8},
-			},
-			"cds-synced": FSMState{
-				Next: map[string]FSMTransition{"zsk-synced": FSMT_RS_9},
-			},
-			"zsk-synced": FSMState{
-				Next: map[string]FSMTransition{"ds-synced": FSMT_RS_10},
-			},
-			"ds-synced": FSMState{
-				Next: map[string]FSMTransition{"signers-synced": FSMT_RS_11},
-			},
-			"signers-synced": FSMState{
-				Next: map[string]FSMTransition{FsmStateStop: FSMT_RS_12},
-			},
-			FsmStateStop: FSMState{
-				Next: map[string]FSMTransition{FsmStateStop: FSMT_RS_13},
-			},
-		},
-	},
-
-	// PROCESS: ZSK-ROLLOVER: This is a real process
-	"zsk-rollover": FSM{
-		Name:         "zsk-rollover",
-		Type:         "single-run",
-		InitialState: FsmStateSignerUnsynced,
-		States: map[string]FSMState{
-			FsmStateSignerUnsynced: FSMState{
-				Next: map[string]FSMTransition{"zsk-known": FSMT_ZR_1},
-			},
-			"zsk-known": FSMState{
-				Next: map[string]FSMTransition{"zsk-synced": FSMT_ZR_2},
-			},
-			"zsk-synced": FSMState{
-				Next: map[string]FSMTransition{"signers-synced": FSMT_ZR_3},
-			},
-			"signers-synced": FSMState{
-				Next: map[string]FSMTransition{FsmStateStop: FSMT_ZR_4},
-			},
-			FsmStateStop: FSMState{
-				Next: map[string]FSMTransition{FsmStateStop: FSMT_ZR_5},
-			},
-		},
-	},
-
-	"ksk-rollover": FSM{
-		Name:         "ksk-rollover",
-		Type:         "permanent",
-		InitialState: "serene-happiness",
-		States:       map[string]FSMState{},
-	},
-}
-
-func (z *Zone) FSMMoveReadyToJSC() bool {
-	if z.Name != "" {
-		fmt.Printf("Zone %s may move from READY to JOIN-SYNC-CDS\n",
-			z.Name)
-		return true
-	}
-	fmt.Printf("Zone %s can not move from READY to JOIN-SYNC-CDS\n",
-		z.Name)
-	return false
 }

--- a/fsm/fsm_spec.go
+++ b/fsm/fsm_spec.go
@@ -4,8 +4,6 @@
 package fsm
 
 import (
-	"fmt"
-
 	music "github.com/DNSSEC-Provisioning/music/common"
 )
 
@@ -19,52 +17,10 @@ const (
 	FsmStateParentNsSynced   = "parent-ns-synced"
 	FsmStateNsesSynced       = "nses-synced"
 	FsmStateNsPropagated     = "ns-propagated"
-	FsmStateStop             = "stop"
+//	FsmStateStop             = "stop"		// XXX: This state is defined in music package
 )
 
-var FsmGenericStop = music.FsmTransitionStopFactory(FsmStateStop)
-
-// PROCESS: ADD-SIGNER
-// defined in fsm_join*.go
-
-// PROCESS: REMOVE-SIGNER
-var FSMT_RS_1 = music.FsmTransitionFactory(FsmStateSignerUnsynced, "ns-known")
-var FSMT_RS_2 = music.FsmTransitionFactory("ns-known", "ns-synced")
-var FSMT_RS_3 = music.FsmTransitionFactory("ns-synced", "csync-published")
-var FSMT_RS_3b = music.FsmTransitionFactory("ns-synced", "delegation-ns-synced")
-var FSMT_RS_4 = music.FsmTransitionFactory("csync-published", "delegation-ns-synced")
-var FSMT_RS_5 = music.FsmTransitionFactory("delegation-ns-synced", "delegation-ns-synced-2")
-var FSMT_RS_6 = music.FsmTransitionFactory("delegation-ns-synced-2", "delegation-ns-synced-3")
-var FSMT_RS_7 = music.FsmTransitionFactory("delegation-ns-synced-3", "cds-known")
-var FSMT_RS_8 = music.FsmTransitionFactory("cds-known", "cds-synced")
-var FSMT_RS_9 = music.FsmTransitionFactory("cds-synced", "zsk-synced")
-var FSMT_RS_10 = music.FsmTransitionFactory("zsk-synced", "ds-synced")
-var FSMT_RS_11 = music.FsmTransitionFactory("ds-synced", "signers-synced")
-var FSMT_RS_12 = music.FsmTransitionFactory("signers-synced", FsmStateStop) // terminator signal
-var FSMT_RS_13 = music.FSMTransition{
-	Desc:     "FSMT_RS_13",
-	Criteria: music.FsmCriteriaFactory(FsmStateStop, FsmStateStop),
-	Action: func(z *music.Zone) bool {
-		fmt.Printf("Enter ACTION for <stop, stop>. zone state: %s\n", z.State)
-		// z.StateTransition(FsmStateStop, FsmStateStop)
-		fmt.Printf("FsmAction (stop): Exiting the remove-signer process seems to have gone well. Yay!\n")
-		return true
-	},
-}
-
-// PROCESS: ADD-ZONE (bogus process, only for testing)
-var FSMT_AZ_1 = music.FsmTransitionFactory("ready", "join-sync-cds")
-var FSMT_AZ_2 = music.FsmTransitionFactory("join-sync-cds", "join-cds-synced")
-var FSMT_AZ_3 = music.FsmTransitionFactory("join-cds-synced", "ready")
-var FSMT_AZ_3b = music.FsmTransitionFactory("join-cds-synced", "foobar")
-var FSMT_AZ_4 = music.FsmTransitionFactory("foobar", "ready")
-
-// PROCESS: ZSK-ROLLOVER
-var FSMT_ZR_1 = music.FsmTransitionFactory(FsmStateSignerUnsynced, "zsks-known")
-var FSMT_ZR_2 = music.FsmTransitionFactory("zsks-known", "zsks-synced")
-var FSMT_ZR_3 = music.FsmTransitionFactory("zsks-synced", "signers-synced")
-var FSMT_ZR_4 = music.FsmTransitionFactory("signers-synced", FsmStateStop)
-var FSMT_ZR_5 = music.FsmTransitionFactory(FsmStateStop, FsmStateStop)
+var FsmGenericStop = music.FsmTransitionStopFactory(music.FsmStateStop)
 
 func NewFSMlist() map[string]music.FSM {
      return FSMlist
@@ -72,29 +28,17 @@ func NewFSMlist() map[string]music.FSM {
 
 var FSMlist = map[string]music.FSM{
 	// PROCESS: ADD-ZONE: This is a bogus process, only for testing.
+
 	"add-zone": music.FSM{
 		Type:         "single-run",
 		InitialState: "ready",
 		States: map[string]music.FSMState{
-			"ready": music.FSMState{
-				Next: map[string]music.FSMTransition{"join-sync-cds": FSMT_AZ_1},
-			},
-			"join-sync-cds": music.FSMState{
-				Next: map[string]music.FSMTransition{"join-cds-synced": FSMT_AZ_2},
-			},
-			"join-cds-synced": music.FSMState{
-				Next: map[string]music.FSMTransition{
-					"ready":  FSMT_AZ_3,
-					"foobar": FSMT_AZ_3b,
-				},
-			},
-			"foobar": music.FSMState{
-				Next: map[string]music.FSMTransition{"ready": FSMT_AZ_4},
-			},
 		},
 	},
 
 	// PROCESS: ADD-SIGNER: This is a real process, from the draft doc.
+	// defined in fsm/join*.go
+
 	"add-signer": music.FSM{
 		Name:         "add-signer",
 		Type:         "single-run",
@@ -124,13 +68,16 @@ DS and NS RRsets in the parent.`,
 				Next: map[string]music.FSMTransition{FsmStateParentNsSynced: FsmJoinParentNsSynced},
 			},
 			FsmStateParentNsSynced: music.FSMState{
-				Next: map[string]music.FSMTransition{FsmStateStop: music.FsmTransitionStopFactory(FsmStateParentNsSynced)},
+				Next: map[string]music.FSMTransition{music.FsmStateStop: music.FsmTransitionStopFactory(FsmStateParentNsSynced)},
 			},
-			FsmStateStop: music.FSMState{
-				Next: map[string]music.FSMTransition{FsmStateStop: FsmGenericStop},
+			music.FsmStateStop: music.FSMState{
+				Next: map[string]music.FSMTransition{music.FsmStateStop: FsmGenericStop},
 			},
 		},
 	},
+
+	// PROCESS: REMOVE-SIGNER: This is a real process, from the draft.
+	// defined in fsm/leave*.go
 
 	"remove-signer": music.FSM{
 		Name:         "remove-signer",
@@ -167,62 +114,10 @@ as that would cause the attached zones to have to go unsigned.`,
 				Next: map[string]music.FSMTransition{FsmStateParentDsSynced: FsmLeaveParentDsSynced},
 			},
 			FsmStateParentDsSynced: music.FSMState{
-				Next: map[string]music.FSMTransition{FsmStateStop: music.FsmTransitionStopFactory(FsmStateParentDsSynced)},
+				Next: map[string]music.FSMTransition{music.FsmStateStop: music.FsmTransitionStopFactory(FsmStateParentDsSynced)},
 			},
-			FsmStateStop: music.FSMState{
-				Next: map[string]music.FSMTransition{FsmStateStop: FsmGenericStop},
-			},
-		},
-	},
-
-	// PROCESS: REMOVE-SIGNER: This is a real process, from the draft doc.
-	"remove-signer-old": music.FSM{
-		Type:         "single-run",
-		InitialState: FsmStateSignerUnsynced,
-		States: map[string]music.FSMState{
-			FsmStateSignerUnsynced: music.FSMState{
-				Next: map[string]music.FSMTransition{"ns-known": FSMT_RS_1},
-			},
-			"ns-known": music.FSMState{
-				Next: map[string]music.FSMTransition{"ns-synced": FSMT_RS_2},
-			},
-			"ns-synced": music.FSMState{
-				Next: map[string]music.FSMTransition{
-					"csync-published":      FSMT_RS_3,
-					"delegation-ns-synced": FSMT_RS_3b,
-				},
-			},
-			"csync-published": music.FSMState{
-				Next: map[string]music.FSMTransition{
-					"delegation-ns-synced": FSMT_RS_4,
-				},
-			},
-			"delegation-ns-synced": music.FSMState{
-				Next: map[string]music.FSMTransition{"delegation-ns-synced-2": FSMT_RS_5},
-			},
-			"delegation-ns-synced-2": music.FSMState{
-				Next: map[string]music.FSMTransition{"delegation-ns-synced-3": FSMT_RS_6},
-			},
-			"delegation-ns-synced-3": music.FSMState{
-				Next: map[string]music.FSMTransition{"cds-known": FSMT_RS_7},
-			},
-			"cds-known": music.FSMState{
-				Next: map[string]music.FSMTransition{"cds-synced": FSMT_RS_8},
-			},
-			"cds-synced": music.FSMState{
-				Next: map[string]music.FSMTransition{"zsk-synced": FSMT_RS_9},
-			},
-			"zsk-synced": music.FSMState{
-				Next: map[string]music.FSMTransition{"ds-synced": FSMT_RS_10},
-			},
-			"ds-synced": music.FSMState{
-				Next: map[string]music.FSMTransition{"signers-synced": FSMT_RS_11},
-			},
-			"signers-synced": music.FSMState{
-				Next: map[string]music.FSMTransition{FsmStateStop: FSMT_RS_12},
-			},
-			FsmStateStop: music.FSMState{
-				Next: map[string]music.FSMTransition{FsmStateStop: FSMT_RS_13},
+			music.FsmStateStop: music.FSMState{
+				Next: map[string]music.FSMTransition{music.FsmStateStop: FsmGenericStop},
 			},
 		},
 	},
@@ -233,21 +128,21 @@ as that would cause the attached zones to have to go unsigned.`,
 		Type:         "single-run",
 		InitialState: FsmStateSignerUnsynced,
 		States: map[string]music.FSMState{
-			FsmStateSignerUnsynced: music.FSMState{
-				Next: map[string]music.FSMTransition{"zsk-known": FSMT_ZR_1},
-			},
-			"zsk-known": music.FSMState{
-				Next: map[string]music.FSMTransition{"zsk-synced": FSMT_ZR_2},
-			},
-			"zsk-synced": music.FSMState{
-				Next: map[string]music.FSMTransition{"signers-synced": FSMT_ZR_3},
-			},
-			"signers-synced": music.FSMState{
-				Next: map[string]music.FSMTransition{FsmStateStop: FSMT_ZR_4},
-			},
-			FsmStateStop: music.FSMState{
-				Next: map[string]music.FSMTransition{FsmStateStop: FSMT_ZR_5},
-			},
+// 			FsmStateSignerUnsynced: music.FSMState{
+// 				Next: map[string]music.FSMTransition{"zsk-known": FSMT_ZR_1},
+// 			},
+// 			"zsk-known": music.FSMState{
+// 				Next: map[string]music.FSMTransition{"zsk-synced": FSMT_ZR_2},
+// 			},
+// 			"zsk-synced": music.FSMState{
+// 				Next: map[string]music.FSMTransition{"signers-synced": FSMT_ZR_3},
+// 			},
+// 			"signers-synced": music.FSMState{
+// 				Next: map[string]music.FSMTransition{FsmStateStop: FSMT_ZR_4},
+// 			},
+// 			FsmStateStop: music.FSMState{
+// 				Next: map[string]music.FSMTransition{FsmStateStop: FSMT_ZR_5},
+// 			},
 		},
 	},
 

--- a/fsm/join_add_cds.go
+++ b/fsm/join_add_cds.go
@@ -11,11 +11,11 @@ import (
 var FsmJoinAddCDS = music.FSMTransition{
 	// XXX: what is the *criteria* for making this transition?
 	Description:         "Once all DNSKEYs are present in all signers (criteria), build CDS/CDNSKEYs RRset and push to all signers (action)",
-	MermaidCriteriaDesc: "Wait for DNSKEY RRset to be consistent",
+
 	MermaidPreCondDesc:  "Wait for all DNSKEY RRsets to be consistent",
 	MermaidActionDesc:   "Compute and publish CDS/CDNSKEY RRsets on all signers",
 	MermaidPostCondDesc: "Verify that all CDS/CDNSKEY RRs are published",
-	Criteria:            JoinAddCdsPreCondition,
+
 	PreCondition:        JoinAddCdsPreCondition,
 	Action:              JoinAddCdsAction,
 	PostCondition:       VerifyCdsPublished,

--- a/fsm/join_parent_ns_synced.go
+++ b/fsm/join_parent_ns_synced.go
@@ -11,18 +11,16 @@ import (
 var FsmJoinParentNsSynced = music.FSMTransition{
 	Description: "Wait for parent to pick up CSYNC and update it's NS records (criteria), then remove CSYNC from all signers and STOP (action)",
 
-	MermaidCriteriaDesc: "Wait for parent to update NS RRset",
 	MermaidPreCondDesc:  "Verify that parent has published updated NS RRset",
 	MermaidActionDesc:   "Remove CSYNC RR from all signers",
 	MermaidPostCondDesc: "Verify that CSYNC has been removed from all signers",
 
-	Criteria:      JoinParentNsSyncedCriteria,
-	PreCondition:  JoinParentNsSyncedCriteria,
+	PreCondition:  JoinParentNsSyncedPreCondition,
 	Action:        JoinParentNsSyncedAction,
 	PostCondition: func(z *music.Zone) bool { return true },
 }
 
-func JoinParentNsSyncedCriteria(z *music.Zone) bool {
+func JoinParentNsSyncedPreCondition(z *music.Zone) bool {
 	nses := make(map[string][]*dns.NS)
 
 	log.Printf("%s: Verifying that NSes are in sync in the parent", z.Name)
@@ -117,6 +115,5 @@ func JoinParentNsSyncedAction(z *music.Zone) bool {
 		log.Printf("%s: Removed CSYNC record sets from %s successfully", z.Name, signer.Name)
 	}
 
-	//    z.StateTransition(FsmStateCsyncAdded, FsmStateParentNsSynced)
 	return true
 }

--- a/fsm/join_sync_dnskeys.go
+++ b/fsm/join_sync_dnskeys.go
@@ -16,11 +16,9 @@ import (
 
 var FsmJoinSyncDnskeys = music.FSMTransition{
 	Description:         "First step when joining, this transistion has no criteria and will sync DNSKEYs between all signers (action)",
-	MermaidCriteriaDesc: "",
 	MermaidPreCondDesc:  "",
 	MermaidActionDesc:   "Update all signer DNSKEY RRsets with all ZSKs",
 	MermaidPostCondDesc: "Verify that all ZSKs are published in signer DNSKEY RRsets",
-	Criteria:            func(z *music.Zone) bool { return true },
 	PreCondition:        func(z *music.Zone) bool { return true },
 	Action:              JoinSyncDnskeys,
 	PostCondition:       VerifyDnskeysSynched,
@@ -28,7 +26,7 @@ var FsmJoinSyncDnskeys = music.FSMTransition{
 
 // XXX: Is it always true that the PostCondition for one action is equal to the PreCondition
 //      for the next action? I think so. I.e. this implementation (VerifyDnskeysSynched) is
-//      extremely similar to the JoinAddCdsCriteria function that is the PreCondition for
+//      extremely similar to the JoinAddCdsPreCondition function that is the PreCondition for
 //      the next step (adding CDS/CDNSKEYs).
 func VerifyDnskeysSynched(z *music.Zone) bool {
 	// 1: for each signer:

--- a/fsm/leave_add_cds.go
+++ b/fsm/leave_add_cds.go
@@ -10,13 +10,17 @@ import (
 
 var FsmLeaveAddCDS = music.FSMTransition{
 	Description: "Once all DNSKEYs are correct in all signers (criteria), build CDS/CDNSKEYs RRset and push to all signers (action)",
-	Criteria:    	 LeaveAddCDSCriteria,
-	PreCondition:    LeaveAddCDSCriteria,
+
+	MermaidPreCondDesc:  "TEXT",
+	MermaidActionDesc:   "TEXT",
+	MermaidPostCondDesc: "TEXT",
+
+	PreCondition:    LeaveAddCDSPreCondition,
 	Action:      	 LeaveAddCDSAction,
 	PostCondition:	 func (z *music.Zone) bool { return true },
 }
 
-func LeaveAddCDSCriteria(z *music.Zone) bool {
+func LeaveAddCDSPreCondition(z *music.Zone) bool {
 	leavingSignerName := "signer2.catch22.se." // Issue #34: Static leaving signer until metadata is in place
 
 	// Need to get signer to remove records for it also, since it's not part of zone SignerMap anymore
@@ -26,7 +30,8 @@ func LeaveAddCDSCriteria(z *music.Zone) bool {
 		return false
 	}
 
-	log.Printf("%s: Verifying that leaving signer %s DNSKEYs has been removed from all signers", z.Name, leavingSigner.Name)
+	log.Printf("%s: Verifying that leaving signer %s DNSKEYs has been removed from all signers",
+			z.Name, leavingSigner.Name)
 
 	stmt, err := z.MusicDB.Prepare("SELECT dnskey FROM zone_dnskeys WHERE zone = ? AND signer = ?")
 	if err != nil {
@@ -121,8 +126,6 @@ func LeaveAddCDSAction(z *music.Zone) bool {
 		log.Printf("%s: Update %s successfully with CDS/CDNSKEY record sets", z.Name, signer.Name)
 	}
 
-	// State transitions are managed in ZoneStepFsm()
-	// z.StateTransition(FsmStateDnskeysSynced, FsmStateCDSAdded)
 	return true
 }
 

--- a/fsm/leave_add_csync.go
+++ b/fsm/leave_add_csync.go
@@ -10,18 +10,17 @@ import (
 
 var FsmLeaveAddCsync = music.FSMTransition{
 	Description: "Once all NS are correct in all signers (criteria), build CSYNC record and push to all signers (action)",
-	MermaidCriteriaDesc: "Wait for all NS RRsets to be in sync in all signers",
+
 	MermaidPreCondDesc:  "Wait for all NS RRsets to be in sync in all signers",
 	MermaidActionDesc:   "Create and publish CSYNC record in all signers",
 	MermaidPostCondDesc: "Verify that the CSYNC record has been removed everywhere",
 	
-	Criteria:    	LeaveAddCsyncCriteria,
-	PreCondition:   LeaveAddCsyncCriteria,
+	PreCondition:   LeaveAddCsyncPreCondition,
 	Action:      	LeaveAddCsyncAction,
 	PostCondition:	func (z *music.Zone) bool { return true },
 }
 
-func LeaveAddCsyncCriteria(z *music.Zone) bool {
+func LeaveAddCsyncPreCondition(z *music.Zone) bool {
 	leavingSignerName := "signer2.catch22.se." // Issue #34: Static leaving signer until metadata is in place
 
 	// Need to get signer to remove records for it also, since it's not part of zone SignerMap anymore
@@ -184,8 +183,6 @@ func LeaveAddCsyncAction(z *music.Zone) bool {
 		log.Printf("%s: Update %s successfully with CSYNC record sets", z.Name, leavingSigner.Name)
 	}
 
-	// State transitions are manageed from ZoneStepFsm()
-	// z.StateTransition(FsmStateNsesSynced, FsmStateCsyncAdded)
 	return true
 }
 

--- a/fsm/leave_parent_ds_synced.go
+++ b/fsm/leave_parent_ds_synced.go
@@ -10,17 +10,17 @@ import (
 
 var FsmLeaveParentDsSynced = music.FSMTransition{
 	Description: "Wait for parent to pick up CDS/CDNSKEYs and update it's DS (criteria), then remove CDS/CDNSKEYs from all signers and STOP (action)",
-	MermaidCriteriaDesc: "Wait for parent to pick up CDS/CDNSKEYs and update the DS record(s)",
-	MermaidPreCondDesc:  "",
+
+	MermaidPreCondDesc:  "Wait for parent to pick up CDS/CDNSKEYs and update the DS record(s)",
 	MermaidActionDesc:   "Remove CDS/CDNSKEYs from all signers",
 	MermaidPostCondDesc: "Verify that all CDS/CDNSKEYs have been removed",
-	Criteria:    	     LeaveParentDsSyncedCriteria,
-	PreCondition:	     func(z *music.Zone) bool { return true },
+
+	PreCondition:	     LeaveParentDsSyncedPreCondition,
 	Action:		     LeaveParentDsSyncedAction,
-	PostCondition:	     func(z *music.Zone) bool { return true },
+	PostCondition:	     func(z *music.Zone) bool { return true }, // XXX: TODO
 }
 
-func LeaveParentDsSyncedCriteria(z *music.Zone) bool {
+func LeaveParentDsSyncedPreCondition(z *music.Zone) bool {
 	cdsmap := make(map[string]*dns.CDS)
 
 	log.Printf("%s: Verifying that DSes in parent are up to date compared to signers CDSes", z.Name)
@@ -97,8 +97,6 @@ func LeaveParentDsSyncedAction(z *music.Zone) bool {
 		log.Printf("%s: Removed CDS/CDNSKEY record sets from %s successfully", z.Name, signer.Name)
 	}
 
-	// State transitions are managed from ZoneStepFsm()
-	// z.StateTransition(FsmStateCDSAdded, FsmStateParentDsSynced)
 	return true
 
 	// TODO: remove state/metadata around leaving signer

--- a/fsm/leave_parent_ns_synced.go
+++ b/fsm/leave_parent_ns_synced.go
@@ -10,19 +10,18 @@ import (
 
 var FsmLeaveParentNsSynced = music.FSMTransition{
 	Description: "Wait for parent to pick up CSYNC and update it's NS records (criteria), then remove CSYNC from all signers (action)",
-	MermaidCriteriaDesc: "Wait for parent to pick up CSYNC and update the NS records",
+
 	MermaidPreCondDesc:  "Wait for parent to pick up CSYNC and update the NS records",
 	MermaidActionDesc:   "Remove CSYNC records from all signers",
 	MermaidPostCondDesc: "Verify that all CSYNC records have been removed",
 	
-	Criteria:    	 LeaveParentNsSyncedCriteria,
-	PreCondition:    LeaveParentNsSyncedCriteria,
+	PreCondition:    LeaveParentNsSyncedPreCondition,
 	Action:      	 LeaveParentNsSyncedAction,
 	PostCondition:	 func (z *music.Zone) bool { return true },
 }
 
 // Verify that NS records in parent are in synched.
-func LeaveParentNsSyncedCriteria(z *music.Zone) bool {
+func LeaveParentNsSyncedPreCondition(z *music.Zone) bool {
 	leavingSignerName := "signer2.catch22.se." // Issue #34: Static leaving signer until metadata is in place
 
 	// Need to get signer to remove records for it also, since it's not part of zone SignerMap anymore
@@ -151,8 +150,6 @@ func LeaveParentNsSyncedAction(z *music.Zone) bool {
 	}
 	log.Printf("%s: Removed CSYNC record sets from %s successfully", z.Name, leavingSigner.Name)
 
-	// State transitions are managed from ZoneStepFsm()
-	// z.StateTransition(FsmStateCsyncAdded, FsmStateParentNsSynced)
 	return true
 }
 

--- a/fsm/leave_sync_dnskeys.go
+++ b/fsm/leave_sync_dnskeys.go
@@ -10,17 +10,17 @@ import (
 
 var FsmLeaveSyncDnskeys = music.FSMTransition{
 	Description: "Once NSes has been propagated (NO criteria), remove DNSKEYs that originated from the leaving signer (Action)",
-	MermaidCriteriaDesc: "todo",
+
 	MermaidPreCondDesc:  "todo",
-	MermaidActionDesc:   "todo",
+	MermaidActionDesc:   "Remove DNSKEYs that originated with the leaving signer",
 	MermaidPostCondDesc: "todo",
-	Criteria:    	 LeaveSyncDnskeysCriteria,
-	PreCondition:    LeaveSyncDnskeysCriteria,
+
+	PreCondition:    LeaveSyncDnskeysPreCondition,
 	Action:      	 LeaveSyncDnskeysAction,
 	PostCondition:	 func (z *music.Zone) bool { return true },
 }
 
-func LeaveSyncDnskeysCriteria(z *music.Zone) bool {
+func LeaveSyncDnskeysPreCondition(z *music.Zone) bool {
 	return true
 }
 
@@ -93,8 +93,6 @@ func LeaveSyncDnskeysAction(z *music.Zone) bool {
 		}
 	}
 
-	// State transitions are managed from ZoneStepFsm()
-	// z.StateTransition(FsmStateNsPropagated, FsmStateDnskeysSynced)
 	return true
 }
 

--- a/fsm/leave_sync_nses.go
+++ b/fsm/leave_sync_nses.go
@@ -10,17 +10,17 @@ import (
 
 var FsmLeaveSyncNses = music.FSMTransition{
 	Description: "First step when leaving, this transistion has no critera and will remove NSes that originated from the leaving signer (Action)",
-	MermaidCriteriaDesc: "None",
+
 	MermaidPreCondDesc:  "None",
 	MermaidActionDesc:   "Remove NS records that only belong to the leaving signer",
 	MermaidPostCondDesc: "Verify that NS records have been removed from zone",
-	Criteria:    	 LeaveSyncNsesCriteria,
-	PreCondition:    func (z *music.Zone) bool { return true },
+
+	PreCondition:    LeaveSyncNsesPreCondition,
 	Action:      	 LeaveSyncNsesAction,
 	PostCondition:    func (z *music.Zone) bool { return true },
 }
 
-func LeaveSyncNsesCriteria(z *music.Zone) bool {
+func LeaveSyncNsesPreCondition(z *music.Zone) bool {
 	return true
 }
 
@@ -79,8 +79,6 @@ func LeaveSyncNsesAction(z *music.Zone) bool {
 	}
 	log.Printf("%s: Removed NSes from %s successfully", z.Name, leavingSigner.Name)
 
-	// State transitions are managed from ZoneStepFsm() 
-	// z.StateTransition(FsmStateSignerUnsynced, FsmStateNsesSynced)
 	return true
 }
 

--- a/fsm/leave_wait_ns.go
+++ b/fsm/leave_wait_ns.go
@@ -17,18 +17,17 @@ func init() {
 
 var FsmLeaveWaitNs = music.FSMTransition{
 	Description: "Wait enough time for parent NS records to propagate (criteria), then continue (NO action)",
-	MermaidCriteriaDesc: "Wait long enough for parent NS records to propagate",
+
 	MermaidPreCondDesc:  "Wait long enough for parent NS records to propagate",
 	MermaidActionDesc:   "Continue after waiting (no action)",
 	MermaidPostCondDesc: "None",
 	
-	Criteria:	LeaveWaitNsCriteria,
-	PreCondition:   LeaveWaitNsCriteria,
+	PreCondition:   LeaveWaitNsPreCondition,
 	Action:      	LeaveWaitNsAction,
 	PostCondition:	func (z *music.Zone) bool { return true },
 }
 
-func LeaveWaitNsCriteria(z *music.Zone) bool {
+func LeaveWaitNsPreCondition(z *music.Zone) bool {
 	if until, ok := zoneWaitNs[z.Name]; ok {
 		if time.Now().Before(until) {
 			log.Printf("%s: Waiting until %s (%s)", z.Name, until.String(), time.Until(until).String())


### PR DESCRIPTION
* removed all the traces of old criteria functions

* remove the state transitions at the tail end of Actions.