### PR TITLE
updated sql to reflect that signergroup dissapeared from signers table

### DIFF
--- a/common/musicdb.go
+++ b/common/musicdb.go
@@ -139,7 +139,7 @@ func (mdb *MusicDB) Prepare(sqlq string) (*sql.Stmt, error) {
 }
 
 const (
-	GSGsql = "SELECT name FROM signergroups WHERE signer=?"
+	GSGsql  = "SELECT name FROM signergroups WHERE signer=?"
 	GSGsql2 = "SELECT name FROM group_signers WHERE signer=?"
 )
 
@@ -174,8 +174,7 @@ func (mdb *MusicDB) GetSignerByName(signername string, apisafe bool) (*Signer, e
 const (
 	GSsql = `
 SELECT name, method, auth,
-  COALESCE (addr, '') AS address,
-  COALESCE (sgroup, '') AS signergroup
+  COALESCE (addr, '') AS address
 FROM signers WHERE name=?`
 )
 
@@ -187,8 +186,8 @@ func (mdb *MusicDB) GetSigner(s *Signer, apisafe bool) (*Signer, error) {
 
 	row := stmt.QueryRow(s.Name)
 
-	var name, method, auth, address, signergroup string
-	switch err = row.Scan(&name, &method, &auth, &address, &signergroup); err {
+	var name, method, auth, address string
+	switch err = row.Scan(&name, &method, &auth, &address); err {
 	case sql.ErrNoRows:
 		// fmt.Printf("GetSigner: Signer \"%s\" does not exist\n", s.Name)
 		return &Signer{
@@ -204,9 +203,9 @@ func (mdb *MusicDB) GetSigner(s *Signer, apisafe bool) (*Signer, error) {
 		// 			  method, auth, address, signergroup)
 		sgs, err := mdb.GetSignerGroups(s.Name)
 		if err != nil {
-		   log.Fatalf("mdb.GetSigner: Error from signer.GetSignerGroups: %v", err)
+			log.Fatalf("mdb.GetSigner: Error from signer.GetSignerGroups: %v", err)
 		}
-		
+
 		dbref := mdb
 		if apisafe {
 			dbref = nil

--- a/common/signerops.go
+++ b/common/signerops.go
@@ -291,7 +291,7 @@ func (mdb *MusicDB) SignerLeaveGroup(dbsigner *Signer, g string) (error, string)
 		}
 		mdb.mu.Unlock()
 		return nil, fmt.Sprintf(
-		"Signer %s was removed from signer group %s immediately (because the signer group has no zones).",
+			"Signer %s was removed from signer group %s immediately (because the signer group has no zones).",
 			dbsigner.Name, g)
 	}
 
@@ -359,7 +359,7 @@ func (mdb *MusicDB) DeleteSigner(dbsigner *Signer) (error, string) {
 
 	// This should be a no-op, as the signer must not be a member of any group.
 	// But we keep it as a GC mechanism in case something has gone wrong.
-	stmt, err = mdb.Prepare(DSsql2) 
+	stmt, err = mdb.Prepare(DSsql2)
 	if err != nil {
 		fmt.Printf("DeleteSigner: Error from db.Prepare '%s': %v\n", DSsql2, err)
 	}
@@ -375,7 +375,7 @@ func (mdb *MusicDB) DeleteSigner(dbsigner *Signer) (error, string) {
 
 const (
 	LSIGsql = `
-SELECT name, method, addr, auth, COALESCE (sgroup, '') AS signergroup
+SELECT name, method, addr, auth
 FROM signers`
 )
 
@@ -393,9 +393,9 @@ func (mdb *MusicDB) ListSigners() (map[string]Signer, error) {
 	if CheckSQLError("ListSigners", LSIGsql, err, false) {
 		return sl, err
 	} else {
-		var name, method, address, auth, signergroup string
+		var name, method, address, auth string
 		for rows.Next() {
-			err := rows.Scan(&name, &method, &address, &auth, &signergroup)
+			err := rows.Scan(&name, &method, &address, &auth)
 			if err != nil {
 				log.Fatal("ListSigners: Error from rows.Next():", err)
 			}


### PR DESCRIPTION
sql looking for 'sgroup' in signers table is causing mucisd to crash.  Fixed. 