### PR TITLE
New process structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,5 @@ certs:
 	openssl req -new -nodes -newkey rsa:2048 -keyout "${CERTDIR}/localhost.key" -out "${CERTDIR}/localhost.csr" -subj "/C=SE/ST=Confusion/L=Lost/O=Music-Certificates/CN=localhost.local"
 	openssl x509 -req -sha256 -days 1024 -in "${CERTDIR}/localhost.csr" -CA "${CERTDIR}/RootCA.pem" -CAkey "${CERTDIR}/RootCA.key" -CAcreateserial -extfile domains.ext -out "${CERTDIR}/localhost.crt"
 
-tags:
+tags:	*/*.go */*/*.go 
 	/Applications/Aquamacs.app/Contents/MacOS/bin/etags */*.go */*/*.go > TAGS

--- a/common/apistructs.go
+++ b/common/apistructs.go
@@ -71,6 +71,7 @@ type ZonePost struct {
 	ToSigner     string
 	SignerGroup  string
 	FSM          string
+	FSMSigner    string
 	FsmNextState string
 	Metakey      string
 	Metavalue    string

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -6,6 +6,7 @@ package music
 const (
 	SignerJoinGroupProcess  = "add-signer"
 	SignerLeaveGroupProcess = "remove-signer"
+	VerifyZoneInSyncProcess = "verify-zone-sync"
 
 	SignerGroupMinimumSigners = 1
 )

--- a/common/fsmops.go
+++ b/common/fsmops.go
@@ -13,7 +13,7 @@ import (
         // "github.com/DNSSEC-Provisioning/music/common"
 )
 
-func (mdb *MusicDB) ZoneAttachFsm(dbzone *Zone, fsm string) (error, string) {
+func (mdb *MusicDB) ZoneAttachFsm(dbzone *Zone, fsm, fsmsigner string) (error, string) {
 
 	if !dbzone.Exists {
 		return fmt.Errorf("Zone %s unknown", dbzone.Name), ""
@@ -41,13 +41,13 @@ func (mdb *MusicDB) ZoneAttachFsm(dbzone *Zone, fsm string) (error, string) {
 	initialstate := process.InitialState
 
 	mdb.mu.Lock()
-	sqlq := "UPDATE zones SET fsm=?, state=? WHERE name=?"
+	sqlq := "UPDATE zones SET fsm=?, fsmsigner=?, state=? WHERE name=?"
 	stmt, err := mdb.db.Prepare(sqlq)
 	if err != nil {
 		fmt.Printf("ZoneAttachFsm: Error from db.Prepare: %v\n", err)
 	}
 
-	_, err = stmt.Exec(fsm, initialstate, dbzone.Name)
+	_, err = stmt.Exec(fsm, fsmsigner, initialstate, dbzone.Name)
 	if CheckSQLError("JoinGroup", sqlq, err, false) {
 		mdb.mu.Unlock()
 		return err, ""

--- a/common/musicdb.go
+++ b/common/musicdb.go
@@ -21,6 +21,7 @@ name        TEXT,
 state       TEXT,
 statestamp  DATETIME,
 fsm         TEXT,
+fsmsigner   TEXT,	
 sgroup      TEXT,
 UNIQUE (name, sgroup)
 )`,

--- a/common/musicdb.go
+++ b/common/musicdb.go
@@ -54,9 +54,12 @@ UNIQUE (name)
 	"signergroups": `CREATE TABLE IF NOT EXISTS 'signergroups' (
 id          INTEGER PRIMARY KEY,
 name        TEXT,
+locked	    BOOLEAN NOT NULL DEFAULT 0 CHECK (locked IN (0, 1)), // locked=1 => group disallow zones joining or leaving
 curprocess  TEXT,
 pendadd	    TEXT,
 pendremove  TEXT,
+numzones    INTEGER,
+numprocesszones	INTEGER,
 UNIQUE (name)
 )`,
 

--- a/common/signergroupops.go
+++ b/common/signergroupops.go
@@ -15,23 +15,13 @@ import (
 
 func (mdb *MusicDB) AddSignerGroup(group string) error {
 	fmt.Printf("AddSignerGroup(%s)\n", group)
-	delcmd := "DELETE FROM signergroups WHERE name=?"
-	addcmd := "INSERT INTO signergroups(name) VALUES (?)"
-	delstmt, err := mdb.Prepare(delcmd)
-	if err != nil {
-		fmt.Printf("AddSignerGroup: Error from db.Prepare: %v\n", err)
-	}
+	addcmd := "INSERT OR REPLACE INTO signergroups(name) VALUES (?)"
 	addstmt, err := mdb.Prepare(addcmd)
 	if err != nil {
 		fmt.Printf("AddSignerGroup: Error from db.Prepare: %v\n", err)
 	}
 
 	mdb.mu.Lock()
-	_, err = delstmt.Exec(group)
-	if CheckSQLError("AddSignerGroup", delcmd, err, false) {
-		mdb.mu.Unlock()
-		return err
-	}
 	_, err = addstmt.Exec(group)
 	mdb.mu.Unlock()
 

--- a/common/signergroupops.go
+++ b/common/signergroupops.go
@@ -43,8 +43,8 @@ func (mdb *MusicDB) AddSignerGroup(group string) error {
 
 const (
       GSGsql1 = `
-SELECT name, COALESCE(curprocess, '') AS curp, COALESCE(pendadd, '') AS padd,
-  COALESCE(pendremove, '') AS prem
+SELECT name, locked, COALESCE(curprocess, '') AS curp, COALESCE(pendadd, '') AS padd,
+  COALESCE(pendremove, '') AS prem, numzones, numprocesszones
 FROM signergroups WHERE name=?`
 )
 
@@ -60,8 +60,11 @@ func (mdb *MusicDB) GetSignerGroup(sg string, apisafe bool) (*SignerGroup, error
 
 	row := stmt.QueryRow(sg)
 
+	var locked bool
 	var name, curprocess, pendadd, pendremove string
-	switch err = row.Scan(&name, &curprocess, &pendadd, &pendremove); err {
+	var numzones, numprocesszones int
+	switch err = row.Scan(&name, &locked, &curprocess, &pendadd,
+	       	     		     &pendremove, &numzones, &numprocesszones); err {
 	case sql.ErrNoRows:
 		fmt.Printf("GetSignerGroup: Signer group \"%s\" does not exist\n", sg)
 		return &SignerGroup{}, fmt.Errorf("GetSignerGroup: Signer group \"%s\" does not exist", sg)
@@ -73,6 +76,9 @@ func (mdb *MusicDB) GetSignerGroup(sg string, apisafe bool) (*SignerGroup, error
 		}
 		return &SignerGroup{
 			Name:			name,
+			Locked:			locked,
+			NumZones:		numzones,
+			NumProcessZones:	numprocesszones,
 			CurrentProcess:		curprocess,
 			PendingAddition:	pendadd,
 			PendingRemoval:		pendremove,

--- a/common/signerops.go
+++ b/common/signerops.go
@@ -43,21 +43,12 @@ func (mdb *MusicDB) AddSigner(dbsigner *Signer, group string) (error, string) {
 			"Unknown signer method: %s. Known methods are: %v", dbsigner.Method, updatermap), ""
 	}
 
-	delstmt, err := mdb.Prepare("DELETE FROM signers WHERE name=?")
-	if err != nil {
-		fmt.Printf("AddSigner: Error from db.Prepare: %v\n", err)
-	}
-	addstmt, err := mdb.Prepare("INSERT INTO signers(name, method, auth, addr) VALUES (?, ?, ?, ?)")
+	addstmt, err := mdb.Prepare("INSERT OR REPLACE INTO signers(name, method, auth, addr) VALUES (?, ?, ?, ?)")
 	if err != nil {
 		fmt.Printf("AddSigner: Error from db.Prepare: %v\n", err)
 	}
 
 	mdb.mu.Lock()
-	_, err = delstmt.Exec(dbsigner.Name)
-	if err != nil {
-		mdb.mu.Unlock()
-		return err, ""
-	}
 	_, err = addstmt.Exec(dbsigner.Name, dbsigner.Method,
 		dbsigner.Auth, dbsigner.Address)
 	mdb.mu.Unlock()

--- a/common/signerops.go
+++ b/common/signerops.go
@@ -193,8 +193,8 @@ func (mdb *MusicDB) SignerJoinGroup(dbsigner *Signer, g string) (error, string) 
 				dbsigner.Name, sg.Name)
 		}
 
-		// At this stage we know that there are now more than one signer and more than zero zones. Hence we
-		// need to enter the add-signer process for all the zones.
+		// At this stage we know that there are now more than one signer and more than zero
+		// zones. Hence we need to enter the add-signer process for all the zones.
 		const sqlq = "UPDATE signergroups SET curprocess=?, pendadd=? WHERE name=?"
 
 		mdb.mu.Lock()
@@ -214,7 +214,7 @@ func (mdb *MusicDB) SignerJoinGroup(dbsigner *Signer, g string) (error, string) 
 		// XXX: this is inefficient, but I don't think we will have enough
 		//      zones in the system for that to be an issue
 		for _, z := range zones {
-			mdb.ZoneAttachFsm(z, SignerJoinGroupProcess) // we know that z exist
+			mdb.ZoneAttachFsm(z, SignerJoinGroupProcess, dbsigner.Name) // we know that z exist
 		}
 		return nil, fmt.Sprintf(
 			"Signer %s has joined signer group %s and %d zones have entered the 'add-signer' process.",
@@ -319,7 +319,7 @@ func (mdb *MusicDB) SignerLeaveGroup(dbsigner *Signer, g string) (error, string)
 	// XXX: this is inefficient, but I don't think we will have enough
 	//      zones in the system for that to be an issue
 	for _, z := range zones {
-		mdb.ZoneAttachFsm(z, SignerLeaveGroupProcess) // we know that z exist
+		mdb.ZoneAttachFsm(z, SignerLeaveGroupProcess, dbsigner.Name) // we know that z exist
 	}
 	return nil, fmt.Sprintf(
 		"Signer %s is in pending removal from signer group %s and therefore %d zones entered the '%s' process.",

--- a/common/structs.go
+++ b/common/structs.go
@@ -37,11 +37,13 @@ type Zone struct {
 
 type SignerGroup struct {
 	Name      	string
+	Locked		bool
 	SignerMap	map[string]*Signer
 	CurrentProcess	string
 	PendingRemoval	string
 	PendingAddition	string
 	NumZones	int
+	NumProcessZones	int
 	State     	string
 	DB        	*MusicDB
 }

--- a/common/structs.go
+++ b/common/structs.go
@@ -29,11 +29,11 @@ type Zone struct {
 	NextState  map[string]bool
 	StopReason string	// possible reason for a state transition not to be possible
 	FSM        string
+	FSMSigner  string
 	SGroup     *SignerGroup
 	SGname     string
 	MusicDB    *MusicDB
 	ZskState   string
-	CurProc	   []ZoneProcess	// 
 }
 
 // A process object encapsulates the change that 

--- a/common/structs.go
+++ b/common/structs.go
@@ -33,6 +33,13 @@ type Zone struct {
 	SGname     string
 	MusicDB    *MusicDB
 	ZskState   string
+	CurProc	   []ZoneProcess	// 
+}
+
+// A process object encapsulates the change that 
+type ZoneProcess struct {
+     Type    string // "add-signer" | "remove-signer"
+     Signer  string // name of signer
 }
 
 type SignerGroup struct {
@@ -40,8 +47,8 @@ type SignerGroup struct {
 	Locked		bool
 	SignerMap	map[string]*Signer
 	CurrentProcess	string
-	PendingRemoval	string
-	PendingAddition	string
+	PendingRemoval	string	// name of leaving signer
+	PendingAddition	string	// name of joining signer
 	NumZones	int
 	NumProcessZones	int
 	State     	string

--- a/common/zoneops.go
+++ b/common/zoneops.go
@@ -348,15 +348,15 @@ func (mdb *MusicDB) ZoneJoinGroup(dbzone *Zone, g string) (error, string) {
 
 	dbzone, _ = mdb.GetZone(dbzone.Name)
 
-	// If the new zone is not already in a process then we put it in the SignerJoinGroupProcess as
-	// a method of ensuring that it is in sync.
+	// If the new zone is not already in a process then we put it in the VerifyZoneInSyncProcess as
+	// a method of ensuring that it is in sync. This process is currently a no-op, but doesn't have to be.
 	if dbzone.FSM == "" || dbzone.FSM == "---" {
-		err, msg := mdb.ZoneAttachFsm(dbzone, SignerJoinGroupProcess)
+		err, msg := mdb.ZoneAttachFsm(dbzone, VerifyZoneInSyncProcess, "all")
 		if err != nil {
 			return err, msg
 		}
 		return nil, fmt.Sprintf(
-			"Zone %s has joined signer group %s and started the process '%s'.", dbzone.Name, g, SignerJoinGroupProcess)
+			"Zone %s has joined signer group %s and started the process '%s'.", dbzone.Name, g, VerifyZoneInSyncProcess)
 	}
 	return nil, fmt.Sprintf(
 		`Zone %s has joined signer group %s but could not start the process '%s'

--- a/fsm/fsm_spec.go
+++ b/fsm/fsm_spec.go
@@ -36,6 +36,13 @@ var FSMlist = map[string]music.FSM{
 		},
 	},
 
+	"verify-zone-sync": music.FSM{
+		Type:         "single-run",
+		InitialState: "ready",
+		States: map[string]music.FSMState{
+		},
+	},
+
 	// PROCESS: ADD-SIGNER: This is a real process, from the draft doc.
 	// defined in fsm/join*.go
 

--- a/fsm/leave_add_cds.go
+++ b/fsm/leave_add_cds.go
@@ -26,11 +26,10 @@ func LeaveAddCDSPreCondition(z *music.Zone) bool {
 	   log.Fatalf("Zone %s in process %s not attached to any signer group.", z.Name, z.FSM)
 	}
 	
-	leavingSignerName := sg.PendingRemoval
+	leavingSignerName := z.FSMSigner  // Issue #34: Static leaving signer until metadata is in place
 	if leavingSignerName == "" {
-		log.Fatalf("Leaving signer name in signer group %s unset.", sg.Name)
+		log.Fatalf("Leaving signer name for zone %s unset.", z.Name)
 	}
-	// leavingSignerName := "signer2.catch22.se." // Issue #34: Static leaving signer until metadata is in place
 
 	// Need to get signer to remove records for it also, since it's not part of zone SignerMap anymore
 	leavingSigner, err := z.MusicDB.GetSignerByName(leavingSignerName, false) // not apisafe

--- a/fsm/leave_add_csync.go
+++ b/fsm/leave_add_csync.go
@@ -26,11 +26,10 @@ func LeaveAddCsyncPreCondition(z *music.Zone) bool {
 	   log.Fatalf("Zone %s in process %s not attached to any signer group.", z.Name, z.FSM)
 	}
 	
-	leavingSignerName := sg.PendingRemoval
+	leavingSignerName := z.FSMSigner // Issue #34: Static leaving signer until metadata is in place
 	if leavingSignerName == "" {
-		log.Fatalf("Leaving signer name in signer group %s unset.", sg.Name)
+		log.Fatalf("Leaving signer name for zone %s unset.", z.Name)
 	}
-	// leavingSignerName := "signer2.catch22.se." // Issue #34: Static leaving signer until metadata is in place
 
 	// Need to get signer to remove records for it also, since it's not part of zone SignerMap anymore
 	leavingSigner, err := z.MusicDB.GetSignerByName(leavingSignerName, false) // not apisafe
@@ -115,8 +114,8 @@ func LeaveAddCsyncPreCondition(z *music.Zone) bool {
 
 // Semantics:
 // 1. Lookup zone signergroup (can only be one)
-// 2. Lookup all signers in signergroup.PendingRemoval
-// 3. For each signer in that list (should really only be one) go through the steps below.
+// 2. Lookup FSMSigner for the zone (can only be one)
+// 3. Go through the steps below.
 // 4. Celebrate Christmas
 
 func LeaveAddCsyncAction(z *music.Zone) bool {
@@ -125,11 +124,10 @@ func LeaveAddCsyncAction(z *music.Zone) bool {
 	   log.Fatalf("Zone %s in process %s not attached to any signer group.", z.Name, z.FSM)
 	}
 	
-	leavingSignerName := sg.PendingRemoval
+	leavingSignerName := z.FSMSigner // Issue #34: Static leaving signer until metadata is in place
 	if leavingSignerName == "" {
-		log.Fatalf("Leaving signer name in signer group %s unset.", sg.Name)
+		log.Fatalf("Leaving signer name for zone %s unset.", z.Name)
 	}
-	// leavingSignerName := "signer2.catch22.se." // Issue #34: Static leaving signer until metadata is in place
 
 	// Need to get signer to remove records for it also, since it's not part of zone SignerMap anymore
 	leavingSigner, err := z.MusicDB.GetSignerByName(leavingSignerName, false) // not apisafe

--- a/fsm/leave_parent_ns_synced.go
+++ b/fsm/leave_parent_ns_synced.go
@@ -27,11 +27,10 @@ func LeaveParentNsSyncedPreCondition(z *music.Zone) bool {
 	   log.Fatalf("Zone %s in process %s not attached to any signer group.", z.Name, z.FSM)
 	}
 	
-	leavingSignerName := sg.PendingRemoval
+	leavingSignerName := z.FSMSigner // Issue #34: Static leaving signer until metadata is in place
 	if leavingSignerName == "" {
-		log.Fatalf("Leaving signer name in signer group %s unset.", sg.Name)
+		log.Fatalf("Leaving signer name for zone %s unset.", z.Name)
 	}
-	// leavingSignerName := "signer2.catch22.se." // Issue #34: Static leaving signer until metadata is in place
 
 	// Need to get signer to remove records for it also, since it's not part of zone SignerMap anymore
 	leavingSigner, err := z.MusicDB.GetSignerByName(leavingSignerName, false) // not apisafe
@@ -132,11 +131,10 @@ func LeaveParentNsSyncedAction(z *music.Zone) bool {
 	   log.Fatalf("Zone %s in process %s not attached to any signer group.", z.Name, z.FSM)
 	}
 	
-	leavingSignerName := sg.PendingRemoval
+	leavingSignerName := z.FSMSigner // Issue #34: Static leaving signer until metadata is in place
 	if leavingSignerName == "" {
-		log.Fatalf("Leaving signer name in signer group %s unset.", sg.Name)
+		log.Fatalf("Leaving signer name for zone %s unset.", z.Name)
 	}
-	// leavingSignerName := "signer2.catch22.se." // Issue #34: Static leaving signer until metadata is in place
 
 	// Need to get signer to remove records for it also, since it's not part of zone SignerMap anymore
 	leavingSigner, err := z.MusicDB.GetSignerByName(leavingSignerName, false) // not apisafe

--- a/fsm/leave_sync_dnskeys.go
+++ b/fsm/leave_sync_dnskeys.go
@@ -30,11 +30,10 @@ func LeaveSyncDnskeysAction(z *music.Zone) bool {
 	   log.Fatalf("Zone %s in process %s not attached to any signer group.", z.Name, z.FSM)
 	}
 	
-	leavingSignerName := sg.PendingRemoval
+	leavingSignerName := z.FSMSigner // Issue #34: Static leaving signer until metadata is in place
 	if leavingSignerName == "" {
-		log.Fatalf("Leaving signer name in signer group %s unset.", sg.Name)
+		log.Fatalf("Leaving signer name in for zone %s unset.", z.Name)
 	}
-	// leavingSignerName := "signer2.catch22.se." // Issue #34: Static leaving signer until metadata is in place
 
 	// Need to get signer to remove records for it also, since it's not part of zone SignerMap anymore
 	leavingSigner, err := z.MusicDB.GetSignerByName(leavingSignerName, false) // not apisafe

--- a/fsm/leave_sync_nses.go
+++ b/fsm/leave_sync_nses.go
@@ -30,11 +30,10 @@ func LeaveSyncNsesAction(z *music.Zone) bool {
 	   log.Fatalf("Zone %s in process %s not attached to any signer group.", z.Name, z.FSM)
 	}
 	
-	leavingSignerName := sg.PendingRemoval
+	leavingSignerName := z.FSMSigner // Issue #34: Static leaving signer until metadata is in place
 	if leavingSignerName == "" {
-		log.Fatalf("Leaving signer name in signer group %s unset.", sg.Name)
+		log.Fatalf("Leaving signer name for zone %s unset.", z.Name)
 	}
-	// leavingSignerName := "signer2.catch22.se." // Issue #34: Static leaving signer until metadata is in place
 
 	// Need to get signer to remove records for it also, since it's not part of zone SignerMap anymore
 	leavingSigner, err := z.MusicDB.GetSignerByName(leavingSignerName, false) // not apisafe

--- a/fsm/leave_wait_ns.go
+++ b/fsm/leave_wait_ns.go
@@ -43,11 +43,10 @@ func LeaveWaitNsPreCondition(z *music.Zone) bool {
 	   log.Fatalf("Zone %s in process %s not attached to any signer group.", z.Name, z.FSM)
 	}
 	
-	leavingSignerName := sg.PendingRemoval
+	leavingSignerName := z.FSMSigner // Issue #34: Static leaving signer until metadata is in place
 	if leavingSignerName == "" {
-		log.Fatalf("Leaving signer name in signer group %s unset.", sg.Name)
+		log.Fatalf("Leaving signer name for zone %s unset.", z.Name)
 	}
-	// leavingSignerName := "signer2.catch22.se." // Issue #34: Static leaving signer until metadata is in place
 
 	// Need to get signer to remove records for it also, since it's not part of zone SignerMap anymore
 	leavingSigner, err := z.MusicDB.GetSignerByName(leavingSignerName, false) // not apisafe

--- a/music-cli/cmd/root.go
+++ b/music-cli/cmd/root.go
@@ -46,7 +46,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&cliconf.Debug, "debug", "d", false, "Debugging output")
 	rootCmd.PersistentFlags().BoolVarP(&showheaders, "headers", "H", false, "Show column headers on output")
 	rootCmd.PersistentFlags().StringVarP(&zonename, "zone", "z", "", "name of zone")
-	rootCmd.PersistentFlags().StringVarP(&signername, "name", "s", "", "name of signer")
+	rootCmd.PersistentFlags().StringVarP(&signername, "signer", "s", "", "name of signer")
 	rootCmd.PersistentFlags().StringVarP(&sgroupname, "group", "g",	"", "name of signer group")
 
 }

--- a/music-cli/cmd/zone.go
+++ b/music-cli/cmd/zone.go
@@ -180,6 +180,11 @@ command.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// failure, _ := ZoneFsm(dns.Fqdn(zonename), fsmname)
 
+		fmt.Println(
+`NOTE: It is not up to a zone to enter a multi signer process (or not), it is
+up to the signer group. This command is only here for development and debuging
+reasons and will disappear.`)
+
 		zone := dns.Fqdn(zonename)
 		if zone == "." {
 			log.Fatalf("ZoneFsm: zone not specified. Terminating.\n")
@@ -189,12 +194,17 @@ command.`,
 			log.Fatalf("ZoneFsm: FSM not specified. Terminating.\n")
 		}
 
+		if signername == "" {
+			log.Fatalf("ZoneFsm: FSM signer not specified. Terminating.\n")
+		}
+
 		data := music.ZonePost{
 			Command: "fsm",
 			Zone: music.Zone{
 				Name: zone,
 			},
 			FSM: fsmname,
+			FSMSigner: signername,
 		}
 		zr, _ := SendZoneCommand(zone, data)
 		if zr.Error {

--- a/musicd/apiserver.go
+++ b/musicd/apiserver.go
@@ -223,8 +223,10 @@ func APIzone(conf *Config) func(w http.ResponseWriter, r *http.Request) {
 				resp.ErrorMsg = err.Error()
 			}
 
+		// XXX: A single zone cannot "choose" to join an FSM, it's the Group that does that.
+		//      This endpoint is only here for development and debugging reasons.
 		case "fsm":
-			err, resp.Msg = mdb.ZoneAttachFsm(dbzone, zp.FSM)
+			err, resp.Msg = mdb.ZoneAttachFsm(dbzone, zp.FSM, zp.FSMSigner)
 			if err != nil {
 				// log.Printf("Error from ZoneAttachFsm: %v", err)
 				resp.Error = true


### PR DESCRIPTION
How about this:

- we store the signer name (the signer to be added or removed) locally within each zone
- we lock the signer group when a process is started (adding or removing a signer)
- we deprecate the "music-cli zone fsm ..." command as it really isn't up to the zone (or the admin) to put a single zone into any particular process, that's a function of the signer group and the same for all zones in the group.