### PR TITLE
Issue130 cds added fix, 

### DIFF
--- a/common/signerops.go
+++ b/common/signerops.go
@@ -382,7 +382,8 @@ func (mdb *MusicDB) SignerLeaveGroup(dbsigner *Signer, g string) (error, string)
 	}
 
 	// https://github.com/DNSSEC-Provisioning/music/issues/130, testing to remove the leaving signer from the signermap. /rog
-	log.Printf("remove %v from SignerMap for %v", dbsigner.Name, sg.Name)
+	log.Printf("remove %v from SignerMap %v: for %v", dbsigner.Name, sg.SignerMap, sg.Name)
+	log.Printf("signerops: signer group %+v\n", sg)
 	delete(sg.SignerMap, dbsigner.Name)
 	if _, member := sg.SignerMap[dbsigner.Name]; member {
 		return fmt.Errorf("Signer %s is still a member of group %s", dbsigner.Name, sg.Name), ""

--- a/common/signerops.go
+++ b/common/signerops.go
@@ -59,16 +59,16 @@ func (mdb *MusicDB) AddSigner(dbsigner *Signer, group string) (error, string) {
 		fmt.Printf("AddSigner: Error from db.Prepare(%s): %v\n", sqlq, err)
 	}
 
-//	mdb.mu.Lock()
+	//	mdb.mu.Lock()
 	tx, err := mdb.Begin()
 	if err != nil {
-	       log.Printf("AddSigner: Error from db.Begin(): %v", err)
+		log.Printf("AddSigner: Error from db.Begin(): %v", err)
 	}
-//	defer tx.Commit()
+	//	defer tx.Commit()
 
 	_, err = addstmt.Exec(dbsigner.Name, dbsigner.Method,
 		dbsigner.AuthStr, dbsigner.Address, dbsigner.Port, dbsigner.UseTcp, dbsigner.UseTSIG)
-//	mdb.mu.Unlock()
+	//	mdb.mu.Unlock()
 	tx.Commit()
 
 	if err != nil {
@@ -136,17 +136,17 @@ func (mdb *MusicDB) UpdateSigner(dbsigner *Signer, us Signer) (error, string) {
 	dbsigner.UseTcp = us.UseTcp
 	dbsigner.UseTSIG = us.UseTSIG
 
-//	mdb.mu.Lock()
+	//	mdb.mu.Lock()
 	tx, err := mdb.Begin()
 	if err != nil {
-	   log.Printf("UpdateSigner: Error from mdb.Begin(): %v", err)
+		log.Printf("UpdateSigner: Error from mdb.Begin(): %v", err)
 	}
-	
+
 	_, err = stmt.Exec(dbsigner.Method, dbsigner.AuthStr, dbsigner.Address, dbsigner.Port,
 		dbsigner.UseTcp, dbsigner.UseTSIG, dbsigner.Name)
-//	mdb.mu.Unlock()
+	//	mdb.mu.Unlock()
 	tx.Commit()
-	
+
 	if CheckSQLError("UpdateSigner", USsql, err, false) {
 		return err, ""
 	}
@@ -238,7 +238,7 @@ func (mdb *MusicDB) SignerJoinGroup(dbsigner *Signer, g string) (error, string) 
 
 		// At this stage we know that there are now more than one signer and more than zero
 		// zones. Hence we need to enter the add-signer process for all the zones.
-		
+
 		const SJGsql3 = "UPDATE signergroups SET curprocess=?, pendadd=?, locked=1 WHERE name=?"
 
 		mdb.mu.Lock()
@@ -261,7 +261,7 @@ func (mdb *MusicDB) SignerJoinGroup(dbsigner *Signer, g string) (error, string) 
 			log.Printf("SignerJoinGroup: calling ZoneAttachFsm(%s, %s, %s)",
 				z.Name, SignerJoinGroupProcess, dbsigner.Name)
 			err, msg := mdb.ZoneAttachFsm(z, SignerJoinGroupProcess, // we know that z exist
-			     	    			 dbsigner.Name, true)    // true=preempt
+				dbsigner.Name, true) // true=preempt
 			if err != nil {
 				log.Printf("SJG: Error from ZAF: %v", err)
 			} else {
@@ -378,8 +378,16 @@ func (mdb *MusicDB) SignerLeaveGroup(dbsigner *Signer, g string) (error, string)
 	//      zones in the system for that to be an issue
 	for _, z := range zones {
 		mdb.ZoneAttachFsm(z, SignerLeaveGroupProcess, // we know that z exist
-				     dbsigner.Name, true)     // true=preempt
+			dbsigner.Name, true) // true=preempt
 	}
+
+	// https://github.com/DNSSEC-Provisioning/music/issues/130, testing to remove the leaving signer from the signermap. /rog
+	log.Printf("remove %v from SignerMap for %v", dbsigner.Name, sg.Name)
+	delete(sg.SignerMap, dbsigner.Name)
+	if _, member := sg.SignerMap[dbsigner.Name]; member {
+		return fmt.Errorf("Signer %s is still a member of group %s", dbsigner.Name, sg.Name), ""
+	}
+
 	return nil, fmt.Sprintf(
 		"Signer %s is in pending removal from signer group %s and therefore %d zones entered the '%s' process.",
 		dbsigner.Name, g, len(zones), SignerLeaveGroupProcess)

--- a/fsm/join_parent_ds_synced.go
+++ b/fsm/join_parent_ds_synced.go
@@ -39,7 +39,7 @@ func JoinParentDsSyncedPreCondition(z *music.Zone) bool {
 
 		if err != nil {
 			z.SetStopReason(fmt.Sprintf("Unable to fetch CDSes from %s: %s",
-							    s.Name, err))
+				s.Name, err))
 			return false
 		}
 
@@ -107,20 +107,22 @@ func JoinParentDsSyncedPreCondition(z *music.Zone) bool {
 	}
 
 	if !parent_up_to_date {
-		return false  // stop-reason defined above
+		return false // stop-reason defined above
 	}
 
 	log.Printf("%s: DS records in parent are up-to-date", z.Name)
 	return true
 }
 
+/*
 func JoinParentDsSyncedAction(z *music.Zone) bool {
 	log.Printf("JoinParentDsSyncedAction: zone %s : No action since we are leaving the CDS records on the signers", z.Name)
 	return true
 }
-
+*/
 // The code below is on "Paus" until we figure out what we want to do with https://github.com/DNSSEC-Provisioning/music/issues/96
-/*
+// unpaused the code, I think we might have to have a prereq that Music is the only controller over CDS/CDSNSKEY RRSET
+///*
 func JoinParentDsSyncedAction(z *music.Zone) bool {
 	log.Printf("%s: Removing CDS/CDNSKEY record sets", z.Name)
 
@@ -148,14 +150,17 @@ func JoinParentDsSyncedAction(z *music.Zone) bool {
 
 	return true
 }
-*/
+
+/*
 
 func VerifyCdsRemoved(z *music.Zone) bool {
 	return true
 }
+*/
 
 // The code below is on "Paus" until we figure out what we want to do with https://github.com/DNSSEC-Provisioning/music/issues/96
-/*
+// unpaused the code, I think we might have to have a prereq that Music is the only controller over CDS/CDSNSKEY RRSET
+///*
 func VerifyCdsRemoved(z *music.Zone) bool {
 	log.Printf("%s: Verify that CDS/CDNSKEY RRsets have been remved", z.Name)
 
@@ -184,11 +189,12 @@ func VerifyCdsRemoved(z *music.Zone) bool {
 
 		if len(cdnskeyrrs) > 0 {
 			z.SetStopReason(fmt.Sprintf("CDNSKEY RRset still published by %s\n",
-							     signer.Name))
+				signer.Name))
 			return false
 		}
 	}
 
 	return true
 }
-*/
+
+//*/

--- a/fsm/leave_add_cds.go
+++ b/fsm/leave_add_cds.go
@@ -37,10 +37,20 @@ func LeaveAddCDSPreCondition(z *music.Zone) bool {
 	}
 
 	// Need to get signer to remove records for it also, since it's not part of zone SignerMap anymore
+	// or is it?? it is not ! so the SGroup.SignerMap in signerops and the z.SGroup.SignerMap is two seperate maps,
 	leavingSigner, err := z.MusicDB.GetSignerByName(leavingSignerName, false) // not apisafe
 	if err != nil {
 		z.SetStopReason(fmt.Sprintf("Unable to get leaving signer %s: %s", leavingSignerName, err))
 		return false
+	}
+
+	// https://github.com/DNSSEC-Provisioning/music/issues/130, testing to remove the leaving signer from the signermap. /rog
+	// this may not be obvious to the casual observer
+	log.Printf("leave_add_cds: %s SignerMap: %v\n", z.Name, z.SGroup.SignerMap)
+	log.Printf("remove %v from SignerMap %v: for %v", leavingSignerName, sg.SignerMap, sg.Name)
+	delete(z.SGroup.SignerMap, leavingSignerName)
+	if _, member := z.SGroup.SignerMap[leavingSignerName]; member {
+		log.Fatalf("Signer %s is still a member of group %s", leavingSignerName, z.SGroup.SignerMap)
 	}
 
 	log.Printf("%s: Verifying that leaving signer %s DNSKEYs has been removed from all signers",
@@ -71,13 +81,6 @@ func LeaveAddCDSPreCondition(z *music.Zone) bool {
 	}
 
 	for _, s := range z.SGroup.SignerMap {
-		// the leaving signer is still in the SignerMap even though the logic in this file seems to think it should not be.
-		// https://github.com/DNSSEC-Provisioning/music/issues/130
-		// common/signerops.go seems to think that it should be. We need to decided what we really want here. /rog
-		if s.Name == leavingSignerName {
-			log.Printf("the leaving signer is still in the SignerMap, not sure which way the bug is but this is a work around for now.")
-			continue
-		}
 		m := new(dns.Msg)
 		m.SetQuestion(z.Name, dns.TypeDNSKEY)
 		c := new(dns.Client)
@@ -115,17 +118,22 @@ func LeaveAddCDSAction(z *music.Zone) bool {
 	cdses := []dns.RR{}
 	cdnskeys := []dns.RR{}
 
-	// https://github.com/DNSSEC-Provisioning/music/issues/130 / rog
 	leavingSignerName := z.FSMSigner // Issue #34: Static leaving signer until metadata is in place
 	if leavingSignerName == "" {
 		log.Fatalf("Leaving signer name for zone %s unset.", z.Name)
 	}
 
+	// https://github.com/DNSSEC-Provisioning/music/issues/130, testing to remove the leaving signer from the signermap. /rog
+	// this may not be obvious to the casual observer
+	log.Printf("leave_add_cds: %s SignerMap: %v\n", z.Name, z.SGroup.SignerMap)
+	log.Printf("remove %v from SignerMap %v: for %v", leavingSignerName, z.SGroup.SignerMap, z.SGroup.Name)
+	delete(z.SGroup.SignerMap, leavingSignerName)
+	if _, member := z.SGroup.SignerMap[leavingSignerName]; member {
+		log.Fatalf("Signer %s is still a member of group %s", leavingSignerName, z.SGroup.SignerMap)
+	}
+
 	for _, s := range z.SGroup.SignerMap {
-		if s.Name == leavingSignerName {
-			log.Printf("issue 130: the leaving signer is still in the SignerMap, not sure which way the bug is but this is a work around for now.")
-			continue
-		}
+		log.Printf("#### leave add cds signer to check: %+v\n ", s)
 		m := new(dns.Msg)
 		m.SetQuestion(z.Name, dns.TypeDNSKEY)
 
@@ -138,6 +146,7 @@ func LeaveAddCDSAction(z *music.Zone) bool {
 		}
 
 		for _, a := range r.Answer {
+			log.Printf("#### leave add cds dnskey response %+v\n ", a)
 			dnskey, ok := a.(*dns.DNSKEY)
 			if !ok {
 				continue
@@ -151,11 +160,8 @@ func LeaveAddCDSAction(z *music.Zone) bool {
 	}
 
 	// Create CDS/CDNSKEY records sets
+	log.Printf("leave_add_cds: %s SignerMap: %v\n", z.Name, z.SGroup.SignerMap)
 	for _, signer := range z.SGroup.SignerMap {
-		if signer.Name == leavingSignerName {
-			log.Printf("issue 130: the leaving signer is still in the SignerMap, not sure which way the bug is but this is a work around for now.")
-			continue
-		}
 		updater := music.GetUpdater(signer.Method)
 		if err := updater.Update(signer, z.Name, z.Name,
 			&[][]dns.RR{cdses, cdnskeys}, nil); err != nil {

--- a/music-cli/cmd/signergroup.go
+++ b/music-cli/cmd/signergroup.go
@@ -80,7 +80,7 @@ func SendSignerGroupCmd(group string, data music.SignerGroupPost) music.SignerGr
 
 	status, buf, err := api.Post("/signergroup", bytebuf.Bytes())
 	if err != nil {
-		log.Fatalf("SendSignerGroupCmd: Error from APIpost:", err)
+		log.Fatalf("SendSignerGroupCmd: Error from APIpost: %v\n", err)
 	}
 	if cliconf.Debug {
 		fmt.Printf("Status: %d\n", status)


### PR DESCRIPTION
Fixed double csync records. I have tested the join and leave process and it works from start to finish.

added a removal av leaving signer from signer map in every leave function.
added the CDS/CDNSKEY removal back to the Add process. We need to take a closer look at this. As for now we need a prerequisite  that MUSIC is the only entity controlling the CDS/CDNSKEY/CSYNC RRSET for the signergroup.