### PR TITLE
More sql.Tx cleanups

### DIFF
--- a/common/dataops.go
+++ b/common/dataops.go
@@ -196,13 +196,13 @@ func (mdb *MusicDB) WriteRRs(signer *Signer, owner, zone string,
 	defer mdb.CloseTransaction(localtx, tx, err)
 
 	const delsql = "DELETE FROM records WHERE zone=? AND owner=? AND signer=? AND rrtype=?"
-	delstmt, err := mdb.Prepare(delsql)
+	delstmt, err := tx.Prepare(delsql)
 	if err != nil {
 		log.Printf("mdb.WriteRRs: Error from db.Prepare(%s): %v", delsql, err)
 	}
 
 	addsql := "INSERT INTO records (zone, owner, signer, rrtype, rdata) VALUES (?, ?, ?, ?, ?)"
-	addstmt, err := mdb.Prepare(addsql)
+	addstmt, err := tx.Prepare(addsql)
 	if err != nil {
 		log.Printf("mdb.WriteRRs: Error from db.Prepare(%s): %v", addsql, err)
 	}
@@ -293,7 +293,7 @@ func (mdb *MusicDB) GetMeta(tx *sql.Tx, z *Zone, key string) (string, bool) {
 	}
 	defer mdb.CloseTransaction(localtx, tx, err)
 
-	stmt, err := mdb.Prepare("SELECT value FROM metadata WHERE zone=? AND key=?")
+	stmt, err := tx.Prepare("SELECT value FROM metadata WHERE zone=? AND key=?")
 	if err != nil {
 		fmt.Printf("GetMeta: Error from db.Prepare: %v\n", err)
 	}

--- a/common/fsmops.go
+++ b/common/fsmops.go
@@ -7,7 +7,7 @@ package music
 import (
         "database/sql"
 	"fmt"
-	"log"
+ 	"log"
 	"strings"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -55,9 +55,9 @@ func (mdb *MusicDB) ZoneAttachFsm(tx *sql.Tx, dbzone *Zone, fsm, fsmsigner strin
 	defer mdb.CloseTransaction(localtx, tx, err)
 
 	sqlq := "UPDATE zones SET fsm=?, fsmsigner=?, state=? WHERE name=?"
-	stmt, err := mdb.db.Prepare(sqlq)
+	stmt, err := tx.Prepare(sqlq)
 	if err != nil {
-		log.Printf("ZoneAttachFsm: Error from db.Prepare: %v\n", err)
+		log.Printf("ZoneAttachFsm: Error from tx.Prepare: %v\n", err)
 	}
 
 	log.Printf("ZAF: Updating zone %s to fsm=%s, fsmsigner=%s", dbzone.Name, fsm, fsmsigner)
@@ -107,9 +107,9 @@ func (mdb *MusicDB) ZoneDetachFsm(tx *sql.Tx, dbzone *Zone, fsm, fsmsigner strin
 	defer mdb.CloseTransaction(localtx, tx, err)
 
 	sqlq := "UPDATE zones SET fsm=?, fsmsigner=?, state=? WHERE name=?"
-	stmt, err := mdb.db.Prepare(sqlq)
+	stmt, err := tx.Prepare(sqlq)
 	if err != nil {
-		fmt.Printf("ZoneDetachFsm: Error from db.Prepare: %v\n", err)
+		fmt.Printf("ZoneDetachFsm: Error from tx.Prepare: %v\n", err)
 	}
 
 	_, err = stmt.Exec("", "", "", dbzone.Name)

--- a/fsm/join_add_csync.go
+++ b/fsm/join_add_csync.go
@@ -134,6 +134,12 @@ func JoinAddCsyncAction(z *music.Zone) bool {
 
 func VerifyCsyncPublished(z *music.Zone) bool {
 	log.Printf("Verifying Publication of CSYNC record sets for %s", z.Name)
+
+	if z.ZoneType == "debug" {
+		log.Printf("VerifyCsyncPublished: zone %s (DEBUG) is automatically ok", z.Name)
+		return true
+	}
+
 	// get all csync records from all the signers
 	csynclist := []*dns.CSYNC{}
 	for _, signer := range z.SGroup.SignerMap {

--- a/fsm/leave_add_csync.go
+++ b/fsm/leave_add_csync.go
@@ -231,6 +231,12 @@ func LeaveAddCsyncAction(z *music.Zone) bool {
 }
 func LeaveVerifyCsyncPublished(z *music.Zone) bool {
 	log.Printf("Verifying Publication of CSYNC record sets for %s", z.Name)
+
+	if z.ZoneType == "debug" {
+		log.Printf("LeaveVerifyCsyncPublished: zone %s (DEBUG) is automatically ok", z.Name)
+		return true
+	}
+
 	csynclist := []*dns.CSYNC{}
 
 	// get all csync records from all the remaining signers in the SignerGroup

--- a/musicd/apiserver.go
+++ b/musicd/apiserver.go
@@ -211,7 +211,11 @@ func APIzone(conf *Config) func(w http.ResponseWriter, r *http.Request) {
 			case "status":
 				var zl = make(map[string]music.Zone, 1)
 				if dbzone.Exists {
-					sg, _ := mdb.GetSignerGroup(nil, dbzone.SGname, true)
+					sg, err := mdb.GetSignerGroup(nil, dbzone.SGname, true)
+					if err != nil {
+					   resp.Error = true
+					   resp.ErrorMsg = err.Error()
+					} else {
 
 					zl[dbzone.Name] = music.Zone{
 						Name:       dbzone.Name,
@@ -223,6 +227,7 @@ func APIzone(conf *Config) func(w http.ResponseWriter, r *http.Request) {
 						SGname:     sg.Name,
 					}
 					resp.Zones = zl
+					}
 
 				} else {
 					message := fmt.Sprintf("Zone %s: not in DB", zp.Zone.Name)
@@ -231,6 +236,7 @@ func APIzone(conf *Config) func(w http.ResponseWriter, r *http.Request) {
 				}
 
 			case "add":
+				fmt.Printf("apiserver:/zone: zone: %v group: '%s'", zp.Zone, zp.SignerGroup)
 				resp.Msg, err = mdb.AddZone(&zp.Zone, zp.SignerGroup, enginecheck)
 				if err != nil {
 					// log.Printf("Error from AddZone: %v", err)

--- a/musicd/dbupdater.go
+++ b/musicd/dbupdater.go
@@ -26,7 +26,7 @@ func dbUpdater(conf *Config) {
 
 	mstmt, err := mdb.Prepare(ZSMsql)
 	if err != nil {
-		log.Fatalf("dbUpdater: Error from db.Prepare(%s) 1: %v\n", ZSMsql, err)
+		log.Fatalf("dbUpdater: Error from mdb.Prepare(%s) 1: %v\n", ZSMsql, err)
 	}
 
 	const DSsql = "UPDATE zones SET fsmstatus='blocked' WHERE name=?"
@@ -56,7 +56,7 @@ func dbUpdater(conf *Config) {
 
 			switch t {
 			case "STOPREASON":
-				_, err := mstmt.Exec(u.Zone, u.Key, u.Value)
+				_, err := tx.Stmt(mstmt).Exec(u.Zone, u.Key, u.Value)
 				if err != nil {
 					if err.(sqlite3.Error).Code == sqlite3.ErrLocked {
 						// database is locked by other connection
@@ -70,7 +70,7 @@ func dbUpdater(conf *Config) {
 						return
 					}
 				}
-				_, err = blockstmt.Exec(u.Zone)
+				_, err = tx.Stmt(blockstmt).Exec(u.Zone)
 				if err != nil {
 					if err.(sqlite3.Error).Code == sqlite3.ErrLocked {
 						// database is locked by other connection

--- a/musicd/fsmengine.go
+++ b/musicd/fsmengine.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"log"
+	"strings"
 	"time"
 
 	"github.com/DNSSEC-Provisioning/music/common"
@@ -94,8 +95,12 @@ func FSMEngine(conf *Config, stopch chan struct{}) {
 	ReportProgress := func() {
 		count = len(zones)
 		if count > 0 {
-			log.Printf("FSM Engine: tried to move these zones forward: %v (will run every %d seconds)",
-				zones, current)
+		   	zonelist := []string{}
+			for _, z := range zones {
+			    zonelist = append(zonelist, z.Name)
+			}
+			log.Printf("FSM Engine: tried to move these zones forward: %s (will run every %d seconds)",
+				strings.Join(zonelist, " "), current)
 		} else {
 			log.Printf("FSM Engine: All zones are currently blocked (will run every %d seconds)",
 				current)

--- a/musicd/main.go
+++ b/musicd/main.go
@@ -127,6 +127,8 @@ func LoadConfig(conf *Config, safemode bool) error {
 
 func main() {
 	var conf Config
+	var err error
+
 	flag.Usage = func() {
 		flag.PrintDefaults()
 	}
@@ -139,7 +141,11 @@ func main() {
 	apistopper := make(chan struct{})
 	conf.Internal.EngineCheck = make(chan music.EngineCheck, 100)
 
-	conf.Internal.MusicDB = music.NewDB(viper.GetString("common.db"), false) // Don't drop status tables if they exist
+	conf.Internal.MusicDB, err = music.NewDB(viper.GetString("db.file"), viper.GetString("db.mode"), false) // Don't drop status tables if they exist
+	if err != nil {
+	   log.Fatalf("Error from NewDB(%s): %v", viper.GetString("db.file"), err)
+	}
+	
 	conf.Internal.TokViper = tokvip
 	conf.Internal.MusicDB.Tokvip = tokvip
 	fsml := fsm.NewFSMlist()

--- a/musicd/musicd.yaml.sample
+++ b/musicd/musicd.yaml.sample
@@ -24,8 +24,13 @@ signers:
       limits:
          fetch:	   5 # ops/s
          update:   2 # ops/s
+
+db:
+   file:	/var/tmp/music.db
+   mode:	WAL # write-ahead logging. WAL mode can not be reverted. Then the db must be dropped and recreated.
+
 common:
-   db:		/var/tmp/music.db
+#   db:		/var/tmp/music.db
    tokenfile:	../etc/musicd.tokens.yaml
    command:	/usr/local/sbin/musicd
    rootca:      ../etc/certs/PublicRootCAs.pem

--- a/scanner/main.go
+++ b/scanner/main.go
@@ -22,7 +22,10 @@ func main() {
 
 	ValidateConfig(nil, DefaultCfgFile) // will terminate on error
 
-	conf.MusicDB = music.NewDB(viper.GetString("scanner.db"), false)
+	conf.MusicDB, err = music.NewDB(viper.GetString("scanner.db"), "", false)
+	if err != nil {
+	   log.Fatalf("Error from NewDB(%s): %v", viper.GetString("scanner.db"), err)
+	}
 
 	// zones is the list of zones the scanner will be monitoring
 	zones := ReadConf(viper.GetString("scanner.zones"))


### PR DESCRIPTION
 * fixed yet another misunderstanding on my part over how sql.Tx works.

* removed a bunch of commented out code.

* added support for SQLite WAL-mode.

* added missing debug support in the new CSYNC post-condition
  testing.

* cleaned up a number of log messages that were printing structs.

* added yet more cases of actually honoring an error return by
  acting on it rather than just logging the error and proceeding
  as if nothing has happened.