### PR TITLE
johani tweaks

### DIFF
--- a/fsm/leave_add_cds.go
+++ b/fsm/leave_add_cds.go
@@ -56,15 +56,11 @@ func LeaveAddCDSPreCondition(z *music.Zone) bool {
 	log.Printf("%s: Verifying that leaving signer %s DNSKEYs has been removed from all signers",
 		z.Name, leavingSigner.Name)
 
-	stmt, err := z.MusicDB.Prepare("SELECT dnskey FROM zone_dnskeys WHERE zone = ? AND signer = ?")
-	if err != nil {
-		log.Printf("%s: Statement prepare failed: %s", z.Name, err)
-		return false
-	}
+	const sqlq = "SELECT dnskey FROM zone_dnskeys WHERE zone = ? AND signer = ?"
 
-	rows, err := stmt.Query(z.Name, leavingSigner.Name)
+	rows, err := z.MusicDB.Query(sqlq, z.Name, leavingSigner.Name)
 	if err != nil {
-		log.Printf("%s: Statement execute failed: %s", z.Name, err)
+		log.Printf("%s: mdb.Query(%s) failed: %s", z.Name, sqlq, err)
 		return false
 	}
 

--- a/fsm/leave_add_csync.go
+++ b/fsm/leave_add_csync.go
@@ -56,15 +56,12 @@ func LeaveAddCsyncPreCondition(z *music.Zone) bool {
 
 	nses := make(map[string]bool)
 
-	stmt, err := z.MusicDB.Prepare("SELECT ns FROM zone_nses WHERE zone = ? AND signer = ?")
-	if err != nil {
-		log.Printf("%s: Statement prepare failed: %s", z.Name, err)
-		return false
-	}
+	const sqlq = "SELECT ns FROM zone_nses WHERE zone = ? AND signer = ?"
 
-	rows, err := stmt.Query(z.Name, leavingSigner.Name)
+	// XXX: Should wrap this in a transaction
+	rows, err := z.MusicDB.Query(sqlq, z.Name, leavingSigner.Name)
 	if err != nil {
-		log.Printf("%s: Statement execute failed: %s", z.Name, err)
+		log.Printf("%s: mdb.Query(%s) failed: %s", z.Name, sqlq, err)
 		return false
 	}
 

--- a/fsm/leave_sync_dnskeys.go
+++ b/fsm/leave_sync_dnskeys.go
@@ -60,15 +60,11 @@ func LeaveSyncDnskeysAction(z *music.Zone) bool {
 
 	log.Printf("%s: Removing DNSKEYs originating from leaving signer %s", z.Name, leavingSigner.Name)
 
-	stmt, err := z.MusicDB.Prepare("SELECT dnskey FROM zone_dnskeys WHERE zone = ? AND signer = ?")
-	if err != nil {
-		log.Printf("%s: Statement prepare failed: %s", z.Name, err)
-		return false
-	}
+	const sqlq = "SELECT dnskey FROM zone_dnskeys WHERE zone = ? AND signer = ?"
 
-	rows, err := stmt.Query(z.Name, leavingSigner.Name)
+	rows, err := z.MusicDB.Query(sqlq, z.Name, leavingSigner.Name)
 	if err != nil {
-		log.Printf("%s: Statement execute failed: %s", z.Name, err)
+		log.Printf("%s: mdb.Query(%s) failed: %s", z.Name, sqlq, err)
 		return false
 	}
 

--- a/fsm/leave_sync_nses.go
+++ b/fsm/leave_sync_nses.go
@@ -60,15 +60,11 @@ func LeaveSyncNsesAction(z *music.Zone) bool {
 
 	log.Printf("%s: Removing NSes originating from leaving signer %s", z.Name, leavingSigner.Name)
 
-	stmt, err := z.MusicDB.Prepare("SELECT ns FROM zone_nses WHERE zone = ? AND signer = ?")
-	if err != nil {
-		log.Printf("%s: Statement prepare failed: %s", z.Name, err)
-		return false
-	}
+	const sqlq = "SELECT ns FROM zone_nses WHERE zone = ? AND signer = ?"
 
-	rows, err := stmt.Query(z.Name, leavingSigner.Name)
+	rows, err := z.MusicDB.Query(sqlq, z.Name, leavingSigner.Name)
 	if err != nil {
-		log.Printf("%s: Statement execute failed: %s", z.Name, err)
+		log.Printf("%s: mdb.Query(%s) failed: %s", z.Name, sqlq, err)
 		return false
 	}
 

--- a/music/musicdb.go
+++ b/music/musicdb.go
@@ -169,6 +169,14 @@ func NewDB(dbfile, dbmode string, force bool) (*MusicDB, error) {
 	return &mdb, nil
 }
 
+func (mdb *MusicDB) Query(sqlq string, args ...interface{}) (*sql.Rows, error) {
+	return mdb.db.Query(sqlq, args...)
+}
+
+func (mdb *MusicDB) Exec(sqlq string, args ...interface{}) (sql.Result, error) {
+	return mdb.db.Exec(sqlq, args...)
+}
+
 func (mdb *MusicDB) Prepare(sqlq string) (*sql.Stmt, error) {
 	return mdb.db.Prepare(sqlq)
 }

--- a/music/signergroupops.go
+++ b/music/signergroupops.go
@@ -400,7 +400,7 @@ func (mdb *MusicDB) CheckIfProcessComplete(tx *sql.Tx, sg *SignerGroup) (bool, s
 		_, err = tx.Exec(sqlq, sg.Name)
 		if err != nil {
 			log.Printf("CheckIfProcessIsComplete: Error from tx.Exec(%s): %v", sqlq, err)
-			return false, fmt.Sprintf("Error from stmt.Exec(%s): %v", sqlq, err), err
+			return false, fmt.Sprintf("Error from tx.Exec(%s): %v", sqlq, err), err
 		}
 
 		if cp == SignerLeaveGroupProcess {
@@ -409,7 +409,7 @@ func (mdb *MusicDB) CheckIfProcessComplete(tx *sql.Tx, sg *SignerGroup) (bool, s
 			if err != nil {
 				log.Printf("CheckIfProcessIsComplete: Error from tx.Exec(%s): %v",
 								      sqlq, err)
-			        return false, fmt.Sprintf("Error from stmt.Exec(%s): %v", sqlq, err), err
+			        return false, fmt.Sprintf("Error from tx.Exec(%s): %v", sqlq, err), err
 			}
 		}
 

--- a/music/structs.go
+++ b/music/structs.go
@@ -24,7 +24,7 @@ type DBUpdate struct {
 }
 
 type EngineCheck struct {
-	Zone string
+	ZoneName string
 }
 
 type Zone struct {

--- a/music/zoneops.go
+++ b/music/zoneops.go
@@ -484,7 +484,7 @@ func (mdb *MusicDB) ZoneJoinGroup(tx *sql.Tx, dbzone *Zone, g string,
 
 	_, err = tx.Exec(sqlq, g, dbzone.Name)
 	if CheckSQLError("JoinGroup", sqlq, err, false) {
-		return fmt.Sprintf("Error from stmt.Exec(%s): %v", sqlq, err), err
+		return fmt.Sprintf("Error from tx.Exec(%s): %v", sqlq, err), err
 	}
 
 	dbzone, _, err = mdb.GetZone(tx, dbzone.Name)

--- a/music/zoneops.go
+++ b/music/zoneops.go
@@ -95,7 +95,7 @@ func (mdb *MusicDB) UpdateZone(dbzone, uz *Zone, enginecheck chan EngineCheck) (
 	}
 
 	if uz.FSMMode == "auto" {
-		enginecheck <- EngineCheck{Zone: dbzone.Name}
+		enginecheck <- EngineCheck{ZoneName: dbzone.Name}
 	}
 
 	return fmt.Sprintf("Zone %s updated.", dbzone.Name), nil
@@ -502,13 +502,13 @@ func (mdb *MusicDB) ZoneJoinGroup(tx *sql.Tx, dbzone *Zone, g string,
 			return msg, err
 		}
 
-		enginecheck <- EngineCheck{Zone: dbzone.Name}
+		enginecheck <- EngineCheck{ZoneName: dbzone.Name}
 		return fmt.Sprintf(
 			"Zone %s has joined signer group %s and started the process '%s'.",
 			dbzone.Name, g, SignerJoinGroupProcess), nil
 	}
 
-	enginecheck <- EngineCheck{Zone: dbzone.Name}
+	enginecheck <- EngineCheck{ZoneName: dbzone.Name}
 	return fmt.Sprintf(
 		`Zone %s has joined signer group %s but could not start the process '%s'
 as the zone is already in process '%s'. Problematic.`, dbzone.Name,

--- a/musicd/apiserver.go
+++ b/musicd/apiserver.go
@@ -339,7 +339,7 @@ func APIzone(conf *Config) func(w http.ResponseWriter, r *http.Request) {
 					var result = map[string][]string{}
 					var rrset []string
 					for k, _ := range sg.Signers() {
-						err, resp.Msg, rrset = mdb.ListRRset(dbzone, k, zp.Owner,
+						err, resp.Msg, rrset = mdb.ListRRset(nil, dbzone, k, zp.Owner,
 							zp.RRtype)
 						if err != nil {
 							log.Fatalf("APIzone: get-rrsets: Error from ListRRset: %v\n", err)
@@ -378,7 +378,7 @@ func APIzone(conf *Config) func(w http.ResponseWriter, r *http.Request) {
 
 			case "list-rrset":
 				var rrset []string
-				err, resp.Msg, rrset = mdb.ListRRset(dbzone, zp.Signer,
+				err, resp.Msg, rrset = mdb.ListRRset(nil, dbzone, zp.Signer,
 					zp.Owner, zp.RRtype)
 				if err != nil {
 					log.Printf("Error from ListRRset: %v", err)

--- a/musicd/config.go
+++ b/musicd/config.go
@@ -83,7 +83,6 @@ type CommonConf struct {
 type InternalConf struct {
 	APIStopCh   chan struct{}
 	EngineCheck chan music.EngineCheck
-	//DB          *sql.DB // This should be gone from the code, can be removed at next clean up. XXX:comment
 	MusicDB     *music.MusicDB
 	TokViper    *viper.Viper
 	DesecFetch  chan music.SignerOp

--- a/musicd/fsmengine.go
+++ b/musicd/fsmengine.go
@@ -35,8 +35,8 @@ func FSMEngine(conf *Config, stopch chan struct{}) {
 	var err error
 	var count int
 	var zones []music.Zone
-	var foo music.EngineCheck
-	var z string
+	var zonename string
+	var checkitem music.EngineCheck
 	var emptymap = map[string]bool{}
 	checkch := conf.Internal.EngineCheck
 
@@ -98,7 +98,6 @@ func FSMEngine(conf *Config, stopch chan struct{}) {
 	}
 
 	ReportProgress := func() {
-		// TODO: find out where zones is set
 		count = len(zones)
 		if count > 0 {
 			zonelist := []string{}
@@ -115,12 +114,12 @@ func FSMEngine(conf *Config, stopch chan struct{}) {
 
 	for {
 		select {
-		case foo = <-checkch:
-			z = foo.Zone
-			if z != "" {
+		case checkitem = <-checkch:
+			zonename = checkitem.ZoneName
+			if zonename != "" {
 				log.Printf("FSM Engine: Someone wants me to check the zone '%s', so I'll do that.",
-					z)
-				zones, err = mdb.PushZones(nil, map[string]bool{z: true}, false)
+					zonename)
+				zones, err = mdb.PushZones(nil, map[string]bool{zonename: true}, false)
 			} else {
 				log.Print("FSM Engine: Someone wants me to do a run now, so I'll do that.")
 				zones, err = mdb.PushZones(nil, emptymap, false)


### PR DESCRIPTION
- manage error return in missing places in FSM engine / engines
- clean up another set of old SQL prepared statements that we don't need or want
- had to add new methods to *MusicDB: Query() and Exec() which is ugly and unfortunate. Should look for better way of doing that (but it is no worse than what we had, and getting rid of the prep statements was the goal here).
