### PR TITLE
WIP: For your consideration: Transaction fix

### DIFF
--- a/music-cli/cmd/signergroup.go
+++ b/music-cli/cmd/signergroup.go
@@ -32,8 +32,8 @@ var addSignerGroupCmd = &cobra.Command{
 			Command: "add",
 			Name:    sgroupname,
 		})
-		if sgr.Message != "" {
-			fmt.Printf("%s\n", sgr.Message)
+		if sgr.Msg != "" {
+			fmt.Printf("%s\n", sgr.Msg)
 		}
 	},
 }
@@ -48,8 +48,8 @@ var deleteSignerGroupCmd = &cobra.Command{
 		}
 
 		sgr := SendSignerGroupCmd(sgroupname, data)
-		if sgr.Message != "" {
-			fmt.Printf("%s\n", sgr.Message)
+		if sgr.Msg != "" {
+			fmt.Printf("%s\n", sgr.Msg)
 		}
 	},
 }

--- a/music/apistructs.go
+++ b/music/apistructs.go
@@ -71,10 +71,10 @@ type TestPost struct {
 }
 
 type TestResponse struct {
-	Time    time.Time
-	Client  string
-	Message string
-	Error	bool
+	Time      	time.Time
+	Client		string
+	Msg		string
+	Error		bool
 	ErrorMsg	string
 }
 
@@ -102,7 +102,6 @@ type ZoneResponse struct {
 	Client   string
 	Error    bool
 	ErrorMsg string
-	// Message        string
 	Msg    string
 	Zones  map[string]Zone
 	RRsets map[string][]string // map[signer][]DNSRecords
@@ -134,7 +133,9 @@ type SignerGroupResponse struct {
 	Time         time.Time
 	Status       int
 	Client       string
-	Message      string
+	Error	     bool
+	ErrorMsg     string
+	Msg	     string
 	SignerGroups map[string]SignerGroup
 }
 

--- a/music/engineops.go
+++ b/music/engineops.go
@@ -5,7 +5,7 @@
 package music
 
 import (
-        "database/sql"
+	"database/sql"
 	"log"
 	"strings"
 )
@@ -16,7 +16,7 @@ SELECT name, zonetype, fsm, fsmsigner, fsmstatus
 FROM zones WHERE fsmmode='auto' AND fsm != '' AND fsmstatus != 'blocked'`
 	AllAutoZones = `
 SELECT name, zonetype, fsm, fsmsigner, fsmstatus
-FROM zones WHERE fsmmode='auto' AND fsm != ''` 
+FROM zones WHERE fsmmode='auto' AND fsm != ''`
 )
 
 // PushZones: Try to move all "auto" zones forward through their respective processes until they
@@ -59,52 +59,59 @@ func (mdb *MusicDB) PushZones(tx *sql.Tx, checkzones map[string]bool, checkall b
 				log.Fatalf("PushZones: Error from rows.Scan: %v", err)
 			}
 
-			z := Zone{ Name: name, FSMStatus: fsmstatus }
+			z := Zone{Name: name, FSMStatus: fsmstatus}
 
 			if len(checkzones) == 0 {
-			   zones = append(zones, z)
+				zones = append(zones, z)
 			} else {
-			   if checkzones[name] {
-			      zones = append(zones, z)
-			   }
+				if checkzones[name] {
+					zones = append(zones, z)
+				}
 			}
 		}
 	}
 
 	var tmperr error
 	if len(zones) > 0 {
-	   	      zonelist := []string{}
-		      for _, z := range zones {
-			    zonelist = append(zonelist, z.Name)
-		      }
+		zonelist := []string{}
+		for _, z := range zones {
+			zonelist = append(zonelist, z.Name)
+		}
 
 		log.Printf("PushZones: will push on these zones: %v", strings.Join(zonelist, " "))
 		for _, z := range zones {
-		        if z.FSMStatus == "delayed" {
-			   log.Printf("PushZones: zone %s is delayed until %v. Leaving for now.",
-			   			  z.Name, "time-when zone-has-waited-long-enough")
+			if z.FSMStatus == "delayed" {
+				log.Printf("PushZones: zone %s is delayed until %v. Leaving for now.",
+					z.Name, "time-when zone-has-waited-long-enough")
 			} else {
-				tmperr = mdb.PushZone(tx, z)
+				tmperr = mdb.PushZone(z)
 				if err == nil {
 					err = tmperr // save first error encountered
 				}
 			}
 		}
-	} 
+	}
 	return zones, err
 }
 
-func (mdb *MusicDB) PushZone(tx *sql.Tx, z Zone) error {
+func (mdb *MusicDB) PushZone(z Zone) error {
+	tx, err := mdb.StartTransactionNG()
+	if err != nil {
+		log.Printf("PushZone: Error from mdb.StartTransactionNG(): %v\n", err)
+		return err
+	}
+	defer mdb.CloseTransactionNG(tx, err)
+
 	dbzone, _, err := mdb.GetZone(tx, z.Name)
 	if err != nil {
-	   return err
+		return err
 	}
 	success, _, _ := mdb.ZoneStepFsm(tx, dbzone, "")
 	oldstate := dbzone.State
 	if success {
 		dbzone, _, err := mdb.GetZone(tx, z.Name)
 		if err != nil {
-		   return err
+			return err
 		}
 		log.Printf("PushZone: successfully transitioned zone '%s' from '%s' to '%s'",
 			z.Name, oldstate, dbzone.State)

--- a/music/fsmops.go
+++ b/music/fsmops.go
@@ -18,12 +18,13 @@ func (mdb *MusicDB) ZoneAttachFsm(tx *sql.Tx, dbzone *Zone, fsm, fsmsigner strin
 
 	var msg string
 
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("ZoneAttachFsm: Error from mdb.StartTransaction(): %v\n", err)
-		return "fail", err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+	if tx == nil { panic("tx=nil") }
+//	localtx, tx, err := mdb.StartTransaction(tx)
+// 	if err != nil {
+// 		log.Printf("ZoneAttachFsm: Error from mdb.StartTransaction(): %v\n", err)
+// 		return "fail", err
+// 	}
+// 	defer mdb.CloseTransaction(localtx, tx, err)
 
 	log.Printf("ZoneAttachFsm: zone: %s fsm: %s fsmsigner: '%s'", dbzone.Name, fsm, fsmsigner)
 	if !dbzone.Exists {
@@ -58,7 +59,7 @@ func (mdb *MusicDB) ZoneAttachFsm(tx *sql.Tx, dbzone *Zone, fsm, fsmsigner strin
 	log.Printf("ZAF: Updating zone %s to fsm=%s, fsmsigner=%s", dbzone.Name, fsm, fsmsigner)
 
 	const sqlq = "UPDATE zones SET fsm=?, fsmsigner=?, state=? WHERE name=?"
-	_, err = tx.Exec(sqlq, fsm, fsmsigner, initialstate, dbzone.Name)
+	_, err := tx.Exec(sqlq, fsm, fsmsigner, initialstate, dbzone.Name)
 	if CheckSQLError("JoinGroup", sqlq, err, false) {
 		return msg, err
 	}
@@ -68,6 +69,7 @@ func (mdb *MusicDB) ZoneAttachFsm(tx *sql.Tx, dbzone *Zone, fsm, fsmsigner strin
 
 func (mdb *MusicDB) ZoneDetachFsm(tx *sql.Tx, dbzone *Zone, fsm, fsmsigner string) (string, error) {
 
+	if tx == nil { panic("tx=nil") }
 	if !dbzone.Exists {
 		return "", fmt.Errorf("Zone %s unknown", dbzone.Name)
 	}
@@ -95,16 +97,16 @@ func (mdb *MusicDB) ZoneDetachFsm(tx *sql.Tx, dbzone *Zone, fsm, fsmsigner strin
 			dbzone.Name, fsm, dbzone.FSM)
 	}
 
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("ZoneDetachFsm: Error from mdb.StartTransaction(): %v\n", err)
-		return "fail", err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+// 	localtx, tx, err := mdb.StartTransaction(tx)
+// 	if err != nil {
+// 		log.Printf("ZoneDetachFsm: Error from mdb.StartTransaction(): %v\n", err)
+// 		return "fail", err
+// 	}
+// 	defer mdb.CloseTransaction(localtx, tx, err)
 
 	const sqlq = "UPDATE zones SET fsm=?, fsmsigner=?, state=? WHERE name=?"
 
-	_, err = tx.Exec(sqlq, "", "", "", dbzone.Name)
+	_, err := tx.Exec(sqlq, "", "", "", dbzone.Name)
 	if CheckSQLError("DetachFsm", sqlq, err, false) {
 		return "", err
 	}
@@ -117,6 +119,7 @@ func (mdb *MusicDB) ZoneDetachFsm(tx *sql.Tx, dbzone *Zone, fsm, fsmsigner strin
 
 func (mdb *MusicDB) ZoneStepFsm(tx *sql.Tx, dbzone *Zone, nextstate string) (bool, string, error) {
 
+	if tx == nil { panic("tx=nil") }
 	if !dbzone.Exists {
 		return false, "", fmt.Errorf("Zone %s unknown", dbzone.Name)
 	}
@@ -131,12 +134,12 @@ func (mdb *MusicDB) ZoneStepFsm(tx *sql.Tx, dbzone *Zone, nextstate string) (boo
 
 	state := dbzone.State
 
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("ZoneStepFsm: Error from mdb.StartTransaction(): %v\n", err)
-		return false, "fail", err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+// 	localtx, tx, err := mdb.StartTransaction(tx)
+// 	if err != nil {
+// 		log.Printf("ZoneStepFsm: Error from mdb.StartTransaction(): %v\n", err)
+// 		return false, "fail", err
+// 	}
+// 	defer mdb.CloseTransaction(localtx, tx, err)
 
 	if state == FsmStateStop {
 		// 1. Zone leaves process
@@ -225,18 +228,19 @@ func (mdb *MusicDB) ZoneStepFsm(tx *sql.Tx, dbzone *Zone, nextstate string) (boo
 func (z *Zone) AttemptStateTransition(tx *sql.Tx, nextstate string,
 	t FSMTransition) (bool, string, error) {
 
-	mdb := z.MusicDB
+	if tx == nil { panic("tx=nil") }
+	// mdb := z.MusicDB
 	currentstate := z.State
 
 	log.Printf("AttemptStateTransition: zone '%s' to state '%s'\n", z.Name, nextstate)
 
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("AttemptStateTransition: Error from mdb.StartTransaction(): %v\n", err)
-		// XXX: What is the correct thing to return here?
-		return false, "fail", err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+// 	localtx, tx, err := mdb.StartTransaction(tx)
+// 	if err != nil {
+// 		log.Printf("AttemptStateTransition: Error from mdb.StartTransaction(): %v\n", err)
+// 		// XXX: What is the correct thing to return here?
+// 		return false, "fail", err
+// 	}
+// 	defer mdb.CloseTransaction(localtx, tx, err)
 
 	// If pre-condition(aka criteria)==true ==> execute action
 	// If post-condition==true ==> change state.

--- a/music/musicdb.go
+++ b/music/musicdb.go
@@ -196,6 +196,15 @@ func (mdb *MusicDB) StartTransaction(tx *sql.Tx) (bool, *sql.Tx, error) {
 	return true, tx, err
 }
 
+func (mdb *MusicDB) StartTransactionNG() (*sql.Tx, error) {
+	tx, err := mdb.Begin()
+	if err != nil {
+		log.Printf("mdb.StartTransactionNG: Error from mdb.Begin(): %v", err)
+		return nil, err
+	}
+	return tx, nil
+}
+
 func (mdb *MusicDB) Rollback(localtx bool, tx *sql.Tx) {
 	if localtx {
 		err := tx.Rollback()
@@ -227,6 +236,30 @@ func (mdb *MusicDB) CloseTransaction(localtx bool, tx *sql.Tx, err error) {
 		// Perhaps not our problem? err != nil and it's the callers problem?
 		// return err
 	}
+	return
+}
+
+func (mdb *MusicDB) CloseTransactionNG(tx *sql.Tx, err error) {
+//	if localtx {
+		if err != nil {
+			// Rollback path
+			err := tx.Rollback()
+			if err != nil {
+				log.Printf("Error from tx.Rollback(): %v", err)
+			}
+		} else {
+			// Commit path
+			err := tx.Commit()
+			if err != nil {
+				log.Printf("Error from tx.Commit(): %v", err)
+			}
+		}
+//	} else {
+		// not a localtx, so we mustn't txRollback(), nor tx.Commit()
+		// But how to signal back what we *would* have done, had it been a localtx?
+		// Perhaps not our problem? err != nil and it's the callers problem?
+		// return err
+//	}
 	return
 }
 

--- a/music/signergroupops.go
+++ b/music/signergroupops.go
@@ -20,14 +20,15 @@ func (mdb *MusicDB) AddSignerGroup(tx *sql.Tx, sg string) (string, error) {
 		return "", errors.New("Signer group without name cannot be created")
 	}
 	
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("AddSignerGroup: Error from mdb.StartTransaction(): %v\n", err)
-		return "fail", err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+	if tx == nil { panic("tx=nil") }
+//	localtx, tx, err := mdb.StartTransaction(tx)
+//	if err != nil {
+//		log.Printf("AddSignerGroup: Error from mdb.StartTransaction(): %v\n", err)
+//		return "fail", err
+//	}
+//	defer mdb.CloseTransaction(localtx, tx, err)
 
-	_, err = mdb.GetSignerGroup(tx, sg, false)
+	_, err := mdb.GetSignerGroup(tx, sg, false)
 	if err == nil {
 	    return fmt.Sprintf("Signergroup %s already exists.", sg), err
 	}
@@ -44,16 +45,16 @@ func (mdb *MusicDB) AddSignerGroup(tx *sql.Tx, sg string) (string, error) {
 
 func (mdb *MusicDB) GetSignerGroup(tx *sql.Tx, sg string, apisafe bool) (*SignerGroup, error) {
 	if sg == "" {
-//		return &SignerGroup{}, errors.New("Empty signer group does not exist")
 		return &SignerGroup{}, nil // A non-existent signergroup is not an error
 	}
 
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
-		return nil, err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+	if tx == nil { panic("tx=nil") }
+//	localtx, tx, err := mdb.StartTransaction(tx)
+//	if err != nil {
+//		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
+//		return nil, err
+//	}
+//	defer mdb.CloseTransaction(localtx, tx, err)
 
 	const sqlq = `
 SELECT name, locked, COALESCE(curprocess, '') AS curp, COALESCE(pendadd, '') AS padd,
@@ -62,6 +63,7 @@ COALESCE(pendremove, '') AS prem FROM signergroups WHERE name=?`
 	row := tx.QueryRow(sqlq, sg)
 
 	var sqllocked int
+	var err error
 	var name, curprocess, pendadd, pendremove string
 	switch err = row.Scan(&name, &sqllocked, &curprocess, &pendadd, &pendremove); err {
 	case sql.ErrNoRows:
@@ -114,14 +116,15 @@ COALESCE(pendremove, '') AS prem FROM signergroups WHERE name=?`
 
 func (mdb *MusicDB) DeleteSignerGroup(tx *sql.Tx, group string) (string, error) {
 
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("DeleteSignerGroup: Error from mdb.StartTransaction(): %v\n", err)
-		return "fail", err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+	if tx == nil { panic("tx=nil") }
+//	localtx, tx, err := mdb.StartTransaction(tx)
+//	if err != nil {
+//		log.Printf("DeleteSignerGroup: Error from mdb.StartTransaction(): %v\n", err)
+//		return "fail", err
+//	}
+//	defer mdb.CloseTransaction(localtx, tx, err)
 
-        _, err = mdb.GetSignerGroup(tx, group, false)
+        _, err := mdb.GetSignerGroup(tx, group, false)
 	if err != nil {
 	    return fmt.Sprintf("Signergroup %s not deleted. Reason: %v", group, err), err
 	}
@@ -154,12 +157,13 @@ func (mdb *MusicDB) DeleteSignerGroup(tx *sql.Tx, group string) (string, error) 
 func (mdb *MusicDB) ListSignerGroups(tx *sql.Tx) (map[string]SignerGroup, error) {
 	var sgl = make(map[string]SignerGroup, 2)
 
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
-		return sgl, err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+	if tx == nil { panic("tx=nil") }
+//	localtx, tx, err := mdb.StartTransaction(tx)
+//	if err != nil {
+//		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
+//		return sgl, err
+//	}
+//	defer mdb.CloseTransaction(localtx, tx, err)
 
 	const sqlq = `
 SELECT name, COALESCE(curprocess, '') AS curp, COALESCE (pendadd, '') AS padd,
@@ -239,12 +243,13 @@ COALESCE(pendremove, '') AS prem, locked FROM signergroups`
 func (sg *SignerGroup) PopulateSigners(tx *sql.Tx) error {
      mdb := sg.DB
 
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
-		return err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+	if tx == nil { panic("tx=nil") }
+// 	localtx, tx, err := mdb.StartTransaction(tx)
+// 	if err != nil {
+// 		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
+// 		return err
+// 	}
+// 	defer mdb.CloseTransaction(localtx, tx, err)
 
 	const sqlcmd = "SELECT name FROM signers WHERE sgroup=?"
 
@@ -277,18 +282,15 @@ func (sg *SignerGroup) PopulateSigners(tx *sql.Tx) error {
 	return nil
 }
 
-// const (
-//	GGSsql1 = "SELECT name, method, auth, COALESCE (addr, '') AS address FROM signers WHERE sgroup=?"
-// )
-
 func (mdb *MusicDB) GetGroupSigners(tx *sql.Tx, name string, apisafe bool) (map[string]*Signer, error) {
 
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
-		return nil, err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+	if tx == nil { panic("tx=nil") }
+// 	localtx, tx, err := mdb.StartTransaction(tx)
+// 	if err != nil {
+// 		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
+// 		return nil, err
+// 	}
+// 	defer mdb.CloseTransaction(localtx, tx, err)
 
 	const sqlq = "SELECT COALESCE (signer, '') AS signer2 FROM group_signers WHERE name=?"
 
@@ -322,12 +324,13 @@ func (mdb *MusicDB) GetGroupSigners(tx *sql.Tx, name string, apisafe bool) (map[
 
 func (mdb *MusicDB) GetGroupSignersNG(tx *sql.Tx, name string, apisafe bool) (map[string]*Signer, error) {
 
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
-		return nil, err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+	if tx == nil { panic("tx=nil") }
+// 	localtx, tx, err := mdb.StartTransaction(tx)
+// 	if err != nil {
+// 		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
+// 		return nil, err
+// 	}
+// 	defer mdb.CloseTransaction(localtx, tx, err)
 
 	signers := map[string]*Signer{}
 
@@ -363,12 +366,13 @@ func (mdb *MusicDB) GetGroupSignersNG(tx *sql.Tx, name string, apisafe bool) (ma
 func (mdb *MusicDB) CheckIfProcessComplete(tx *sql.Tx, sg *SignerGroup) (bool, string, error) {
 	var msg string
 
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
-		return false, err.Error(), err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+	if tx == nil { panic("tx=nil") }
+// 	localtx, tx, err := mdb.StartTransaction(tx)
+// 	if err != nil {
+// 		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
+// 		return false, err.Error(), err
+// 	}
+// 	defer mdb.CloseTransaction(localtx, tx, err)
 
 	zones, _ := mdb.GetSignerGroupZones(tx, sg)
 	pzones := 0
@@ -397,7 +401,7 @@ func (mdb *MusicDB) CheckIfProcessComplete(tx *sql.Tx, sg *SignerGroup) (bool, s
 			log.Fatalf("CheckIfProcessIsComplete: Unknown process: %s. Terminating.", cp)
 		}
 
-		_, err = tx.Exec(sqlq, sg.Name)
+		_, err := tx.Exec(sqlq, sg.Name)
 		if err != nil {
 			log.Printf("CheckIfProcessIsComplete: Error from tx.Exec(%s): %v", sqlq, err)
 			return false, fmt.Sprintf("Error from tx.Exec(%s): %v", sqlq, err), err

--- a/music/signerops.go
+++ b/music/signerops.go
@@ -22,12 +22,13 @@ func (mdb *MusicDB) AddSigner(tx *sql.Tx, dbsigner *Signer, group string) (strin
 	var err error
 	msg := fmt.Sprintf("Failed to add new signer %s.", dbsigner.Name)
 
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("AddSigner: Error from mdb.StartTransaction(): %v\n", err)
-		return msg, err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+	if tx == nil { panic("tx == nil") }
+//	localtx, tx, err := mdb.StartTransaction(tx)
+//	if err != nil {
+//		log.Printf("AddSigner: Error from mdb.StartTransaction(): %v\n", err)
+//		return msg, err
+//	}
+//	defer mdb.CloseTransaction(localtx, tx, err)
 
 	if dbsigner.Exists {
 		return "", fmt.Errorf("Signer %s already present in system.",
@@ -90,12 +91,13 @@ func (mdb *MusicDB) UpdateSigner(tx *sql.Tx, dbsigner *Signer, us Signer) (strin
 			dbsigner.Name)
 	}
 
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
-		return fmt.Sprintf("UpdateSigner: Error from mdb.StartTransaction(): %v", err), err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+	if tx == nil { panic("tx == nil") }
+//	localtx, tx, err := mdb.StartTransaction(tx)
+//	if err != nil {
+//		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
+//		return fmt.Sprintf("UpdateSigner: Error from mdb.StartTransaction(): %v", err), err
+//	}
+//	defer mdb.CloseTransaction(localtx, tx, err)
 
 	updatermap := ListUpdaters()
 	_, ok := updatermap[dbsigner.Method]
@@ -152,12 +154,13 @@ func (mdb *MusicDB) SignerJoinGroup(tx *sql.Tx, dbsigner *Signer, g string) (str
 	var sg *SignerGroup
 	var err error
 
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
-		return "SignerJoinGroup: Error starting transaction", err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+	if tx == nil { panic("tx == nil") }
+//	localtx, tx, err := mdb.StartTransaction(tx)
+//	if err != nil {
+//		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
+//		return "SignerJoinGroup: Error starting transaction", err
+//	}
+//	defer mdb.CloseTransaction(localtx, tx, err)
 
 	if !dbsigner.Exists {
 		return "", fmt.Errorf("Signer %s is unknown.", dbsigner.Name)
@@ -266,12 +269,13 @@ func (mdb *MusicDB) SignerLeaveGroup(tx *sql.Tx, dbsigner *Signer, g string) (st
 	var sg *SignerGroup
 	var err error
 
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
-		return "Error starting transaction", err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+	if tx == nil { panic("tx==nil") }
+//	localtx, tx, err := mdb.StartTransaction(tx)
+//	if err != nil {
+//		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
+//		return "Error starting transaction", err
+//	}
+//	defer mdb.CloseTransaction(localtx, tx, err)
 
 	if !dbsigner.Exists {
 		return "", fmt.Errorf("Signer %s is unknown.", dbsigner.Name)
@@ -370,12 +374,13 @@ const ()
 //      Full stop.
 func (mdb *MusicDB) DeleteSigner(tx *sql.Tx, dbsigner *Signer) (string, error) {
 
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
-		return "fail", err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+     	if tx == nil { panic("tx==nil") }
+//	localtx, tx, err := mdb.StartTransaction(tx)
+//	if err != nil {
+//		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
+//		return "fail", err
+//	}
+//	defer mdb.CloseTransaction(localtx, tx, err)
 
 	sgs := dbsigner.SignerGroups
 	if len(sgs) != 0 {
@@ -385,7 +390,7 @@ func (mdb *MusicDB) DeleteSigner(tx *sql.Tx, dbsigner *Signer) (string, error) {
 	}
 
 	const dsql = "DELETE FROM signers WHERE name=?"
-	_, err = tx.Exec(dsql, dbsigner.Name)
+	_, err := tx.Exec(dsql, dbsigner.Name)
 	if CheckSQLError("DeleteSigner", dsql, err, false) {
 		return "", err
 	}
@@ -404,12 +409,13 @@ func (mdb *MusicDB) DeleteSigner(tx *sql.Tx, dbsigner *Signer) (string, error) {
 func (mdb *MusicDB) ListSigners(tx *sql.Tx) (map[string]Signer, error) {
 	var sl = make(map[string]Signer, 2)
 
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
-		return nil, err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+	if tx == nil { panic("tx==nil") }
+//	localtx, tx, err := mdb.StartTransaction(tx)
+//	if err != nil {
+//		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
+//		return nil, err
+//	}
+//	defer mdb.CloseTransaction(localtx, tx, err)
 
 	const sqlq = "SELECT name, method, addr, auth, port FROM signers"
 	rows, err := tx.Query(sqlq)

--- a/music/zoneops.go
+++ b/music/zoneops.go
@@ -22,7 +22,8 @@ func (mdb *MusicDB) AddZone(tx *sql.Tx, z *Zone, group string, enginecheck chan 
 
 	fmt.Printf("AddZone: Zone: %v group: '%s'", z, group)
 
-	// var tx *sql.Tx
+	if tx == nil { panic("tx=nil") }
+//	var tx *sql.Tx
 //	localtx, tx, err := mdb.StartTransaction(tx)
 //	if err != nil {
 //		log.Printf("AddZone: Error from mdb.StartTransaction(): %v\n", err)
@@ -71,7 +72,8 @@ VALUES (?, ?, ?, datetime('now'), ?, ?)`
 func (mdb *MusicDB) UpdateZone(tx *sql.Tx, dbzone, uz *Zone, enginecheck chan EngineCheck) (string, error) {
 	log.Printf("UpdateZone: zone: %v", uz)
 
-	// var tx *sql.Tx
+	if tx == nil { panic("tx=nil") }
+//	var tx *sql.Tx
 //	localtx, tx, err := mdb.StartTransaction(tx)
 //	if err != nil {
 //		log.Printf("UpdateZone: Error from mdb.StartTransaction(): %v\n", err)
@@ -106,6 +108,7 @@ func (mdb *MusicDB) DeleteZone(tx *sql.Tx, z *Zone) (string, error) {
 		return "", fmt.Errorf("Zone %s not present in MuSiC system.", z.Name)
 	}
 
+	if tx == nil { panic("tx=nil") }
 //	var tx *sql.Tx
 //	localtx, tx, err := mdb.StartTransaction(tx)
 //	if err != nil {
@@ -172,12 +175,13 @@ func (z *Zone) SetStopReason(value string) (error, string) {
 func (z *Zone) SetDelayReason(tx *sql.Tx, value string, delay time.Duration) (string, error) {
 	mdb := z.MusicDB
 
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("SetDelayReason: Error from mdb.StartTransaction(): %v\n", err)
-		return "fail", err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+	if tx == nil { panic("tx=nil") }
+// 	localtx, tx, err := mdb.StartTransaction(tx)
+// 	if err != nil {
+// 		log.Printf("SetDelayReason: Error from mdb.StartTransaction(): %v\n", err)
+// 		return "fail", err
+// 	}
+// 	defer mdb.CloseTransaction(localtx, tx, err)
 
 	msg, err := mdb.ZoneSetMeta(tx, z, "delay-reason", value)
 	if err != nil {
@@ -199,15 +203,16 @@ func (mdb *MusicDB) ZoneSetMeta(tx *sql.Tx, z *Zone, key, value string) (string,
 		return "", fmt.Errorf("Zone %s not present in MuSiC system.", z.Name)
 	}
 
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("ZoneSetMeta: Error from mdb.StartTransaction(): %v\n", err)
-		return "fail", err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+	if tx == nil { panic("tx=nil") }
+//	localtx, tx, err := mdb.StartTransaction(tx)
+//	if err != nil {
+//		log.Printf("ZoneSetMeta: Error from mdb.StartTransaction(): %v\n", err)
+//		return "fail", err
+//	}
+//	defer mdb.CloseTransaction(localtx, tx, err)
 
 	const sqlq = "INSERT OR REPLACE INTO metadata (zone, key, time, value) VALUES (?, ?, datetime('now'), ?)"
-	_, err = tx.Exec(sqlq, z.Name, key, value)
+	_, err := tx.Exec(sqlq, z.Name, key, value)
 	if CheckSQLError("ZoneSetMeta", sqlq, err, false) {
 		return "", err
 	}
@@ -230,12 +235,13 @@ func (mdb *MusicDB) ZoneGetMeta(tx *sql.Tx, z *Zone, key string) (string, error)
 		return "", fmt.Errorf("Zone %s not present in MuSiC system.", z.Name)
 	}
 
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("ZoneGetMeta: Error from mdb.StartTransaction(): %v\n", err)
-		return "fail", err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+	if tx == nil { panic("tx=nil") }
+//	localtx, tx, err := mdb.StartTransaction(tx)
+//	if err != nil {
+// 		log.Printf("ZoneGetMeta: Error from mdb.StartTransaction(): %v\n", err)
+// 		return "fail", err
+// 	}
+// 	defer mdb.CloseTransaction(localtx, tx, err)
 
 	const sqlq = "SELECT value FROM metadata WHERE zone=? AND key=?"
 
@@ -259,12 +265,13 @@ func (z *Zone) StateTransition(tx *sql.Tx, from, to string) error {
 	mdb := z.MusicDB
 	fsm := z.FSM
 
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("StateTransition: Error from mdb.StartTransaction(): %v\n", err)
-		return err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+	if tx == nil { panic("tx=nil") }
+// 	localtx, tx, err := mdb.StartTransaction(tx)
+// 	if err != nil {
+// 		log.Printf("StateTransition: Error from mdb.StartTransaction(): %v\n", err)
+// 		return err
+// 	}
+// 	defer mdb.CloseTransaction(localtx, tx, err)
 
 	fmt.Printf("This is %s StateTransition(%s-->%s) in process %s\n", z.Name, from, to, fsm)
 	if fsm == "" {
@@ -282,7 +289,7 @@ func (z *Zone) StateTransition(tx *sql.Tx, from, to string) error {
 		fsm = "---"
 	}
 
-	_, err = tx.Exec("UPDATE zones SET state=?, fsm=?, fsmstatus=? WHERE name=?", to, fsm, "", z.Name)
+	_, err := tx.Exec("UPDATE zones SET state=?, fsm=?, fsmstatus=? WHERE name=?", to, fsm, "", z.Name)
 	if err != nil {
 		log.Printf("StateTransition: Error from tx.Exec(): %v\n", err)
 		return err
@@ -309,13 +316,14 @@ func (mdb *MusicDB) ApiGetZone(zonename string) (*Zone, bool, error) {
 
 func (mdb *MusicDB) GetZone(tx *sql.Tx, zonename string) (*Zone, bool, error) {
 
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("GetZone: Error from mdb.StartTransaction(): %v\n", err)
-		// return err, "fail"
-		return nil, false, err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+	if tx == nil { panic("tx=nil") }
+// 	localtx, tx, err := mdb.StartTransaction(tx)
+// 	if err != nil {
+// 		log.Printf("GetZone: Error from mdb.StartTransaction(): %v\n", err)
+// 		// return err, "fail"
+// 		return nil, false, err
+// 	}
+// 	defer mdb.CloseTransaction(localtx, tx, err)
 
 	const qsql = `
 SELECT name, zonetype, state, fsmmode, COALESCE(statestamp, datetime('now')) AS timestamp,
@@ -325,7 +333,7 @@ FROM zones WHERE name=?`
 	row := tx.QueryRow(qsql, zonename)
 
 	var name, zonetype, state, fsmmode, timestamp, fsm, fsmsigner, signergroup string
-	switch err = row.Scan(&name, &zonetype, &state, &fsmmode, &timestamp,
+	switch err := row.Scan(&name, &zonetype, &state, &fsmmode, &timestamp,
 		&fsm, &fsmsigner, &signergroup); err {
 	case sql.ErrNoRows:
 		// fmt.Printf("GetZone: Zone \"%s\" does not exist\n", zonename)
@@ -379,12 +387,13 @@ FROM zones WHERE name=?`
 func (mdb *MusicDB) GetSignerGroupZones(tx *sql.Tx, sg *SignerGroup) ([]*Zone, error) {
 	var zones = []*Zone{}
 
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("GetSignerGroup: Error from mdb.StartTransaction(): %v\n", err)
-		return zones, err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+	if tx == nil { panic("tx=nil") }
+// 	localtx, tx, err := mdb.StartTransaction(tx)
+// 	if err != nil {
+// 		log.Printf("GetSignerGroup: Error from mdb.StartTransaction(): %v\n", err)
+// 		return zones, err
+// 	}
+// 	defer mdb.CloseTransaction(localtx, tx, err)
 
 	const sqlq = `
 SELECT name, state, COALESCE(statestamp, datetime('now')) AS timestamp, fsm FROM zones WHERE sgroup=?`
@@ -449,6 +458,8 @@ func (mdb *MusicDB) ZoneJoinGroup(tx *sql.Tx, dbzone *Zone, g string,
 	var group *SignerGroup
 	var err error
 
+	if tx == nil { panic("tx=nil") }
+
 	if !dbzone.Exists {
 		return "", fmt.Errorf("Zone %s unknown", dbzone.Name)
 	}
@@ -473,12 +484,12 @@ func (mdb *MusicDB) ZoneJoinGroup(tx *sql.Tx, dbzone *Zone, g string,
 
 	}
 
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
-		return "fail", err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+// 	localtx, tx, err := mdb.StartTransaction(tx)
+// 	if err != nil {
+// 		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
+// 		return "fail", err
+// 	}
+// 	defer mdb.CloseTransaction(localtx, tx, err)
 
 	const sqlq = "UPDATE zones SET sgroup=? WHERE name=?"
 
@@ -530,12 +541,13 @@ func (mdb *MusicDB) ZoneLeaveGroup(tx *sql.Tx, dbzone *Zone, g string) (string, 
 		return "", fmt.Errorf("Zone %s unknown", dbzone.Name)
 	}
 
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
-		return "fail", err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+	if tx == nil { panic("tx=nil") }
+// 	localtx, tx, err := mdb.StartTransaction(tx)
+// 	if err != nil {
+// 		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
+// 		return "fail", err
+// 	}
+// 	defer mdb.CloseTransaction(localtx, tx, err)
 
 	if _, err := mdb.GetSignerGroup(tx, g, false); err != nil { // not apisafe
 		return "", err
@@ -550,7 +562,7 @@ func (mdb *MusicDB) ZoneLeaveGroup(tx *sql.Tx, dbzone *Zone, g string) (string, 
 
 	const sqlq = "UPDATE zones SET sgroup='' WHERE name=?"
 
-	_, err = tx.Exec(sqlq, dbzone.Name)
+	_, err := tx.Exec(sqlq, dbzone.Name)
 	if CheckSQLError("ZoneLeaveGroup", sqlq, err, false) {
 		return "", err
 	}
@@ -563,16 +575,17 @@ const (
 	layout = "2006-01-02 15:04:05"
 )
 
-func (mdb *MusicDB) ListZones() (map[string]Zone, error) {
+func (mdb *MusicDB) ListZones(tx *sql.Tx) (map[string]Zone, error) {
 	var zl = make(map[string]Zone, 10)
 
-	var tx *sql.Tx
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
-		return zl, err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+	if tx == nil { panic("tx=nil") }
+// 	var tx *sql.Tx
+// 	localtx, tx, err := mdb.StartTransaction(tx)
+// 	if err != nil {
+// 		log.Printf("ZoneJoinGroup: Error from mdb.StartTransaction(): %v\n", err)
+// 		return zl, err
+// 	}
+// 	defer mdb.CloseTransaction(localtx, tx, err)
 
 	const sqlq = `
 SELECT name, zonetype, state, fsm, fsmmode, fsmstatus,

--- a/music/zoneops.go
+++ b/music/zoneops.go
@@ -18,11 +18,11 @@ func (z *Zone) SignerGroup() *SignerGroup {
 	return z.SGroup
 }
 
-func (mdb *MusicDB) AddZone(z *Zone, group string, enginecheck chan EngineCheck) (string, error) {
+func (mdb *MusicDB) AddZone(tx *sql.Tx, z *Zone, group string, enginecheck chan EngineCheck) (string, error) {
 
 	fmt.Printf("AddZone: Zone: %v group: '%s'", z, group)
 
-	var tx *sql.Tx
+	// var tx *sql.Tx
 	localtx, tx, err := mdb.StartTransaction(tx)
 	if err != nil {
 		log.Printf("AddZone: Error from mdb.StartTransaction(): %v\n", err)
@@ -68,10 +68,10 @@ VALUES (?, ?, ?, datetime('now'), ?, ?)`
 		fqdn), nil
 }
 
-func (mdb *MusicDB) UpdateZone(dbzone, uz *Zone, enginecheck chan EngineCheck) (string, error) {
+func (mdb *MusicDB) UpdateZone(tx *sql.Tx, dbzone, uz *Zone, enginecheck chan EngineCheck) (string, error) {
 	log.Printf("UpdateZone: zone: %v", uz)
 
-	var tx *sql.Tx
+	// var tx *sql.Tx
 	localtx, tx, err := mdb.StartTransaction(tx)
 	if err != nil {
 		log.Printf("UpdateZone: Error from mdb.StartTransaction(): %v\n", err)
@@ -101,12 +101,12 @@ func (mdb *MusicDB) UpdateZone(dbzone, uz *Zone, enginecheck chan EngineCheck) (
 	return fmt.Sprintf("Zone %s updated.", dbzone.Name), nil
 }
 
-func (mdb *MusicDB) DeleteZone(z *Zone) (string, error) {
+func (mdb *MusicDB) DeleteZone(tx *sql.Tx, z *Zone) (string, error) {
 	if !z.Exists {
 		return "", fmt.Errorf("Zone %s not present in MuSiC system.", z.Name)
 	}
 
-	var tx *sql.Tx
+//	var tx *sql.Tx
 	localtx, tx, err := mdb.StartTransaction(tx)
 	if err != nil {
 		log.Printf("DeleteZone: Error from mdb.StartTransaction(): %v\n", err)

--- a/music/zoneops.go
+++ b/music/zoneops.go
@@ -23,12 +23,12 @@ func (mdb *MusicDB) AddZone(tx *sql.Tx, z *Zone, group string, enginecheck chan 
 	fmt.Printf("AddZone: Zone: %v group: '%s'", z, group)
 
 	// var tx *sql.Tx
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("AddZone: Error from mdb.StartTransaction(): %v\n", err)
-		return "fail", err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+//	localtx, tx, err := mdb.StartTransaction(tx)
+//	if err != nil {
+//		log.Printf("AddZone: Error from mdb.StartTransaction(): %v\n", err)
+//		return "fail", err
+//	}
+//	defer mdb.CloseTransaction(localtx, tx, err)
 
 	fqdn := dns.Fqdn(z.Name)
 	dbzone, _, err := mdb.GetZone(tx, fqdn)
@@ -72,12 +72,12 @@ func (mdb *MusicDB) UpdateZone(tx *sql.Tx, dbzone, uz *Zone, enginecheck chan En
 	log.Printf("UpdateZone: zone: %v", uz)
 
 	// var tx *sql.Tx
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("UpdateZone: Error from mdb.StartTransaction(): %v\n", err)
-		return "fail", err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+//	localtx, tx, err := mdb.StartTransaction(tx)
+//	if err != nil {
+//		log.Printf("UpdateZone: Error from mdb.StartTransaction(): %v\n", err)
+//		return "fail", err
+//	}
+//	defer mdb.CloseTransaction(localtx, tx, err)
 
 	if uz.ZoneType != "" {
 		dbzone.ZoneType = uz.ZoneType
@@ -89,7 +89,7 @@ func (mdb *MusicDB) UpdateZone(tx *sql.Tx, dbzone, uz *Zone, enginecheck chan En
 
 	const sqlq = "UPDATE zones SET zonetype=?, fsmmode=? WHERE name=?"
 
-	_, err = tx.Exec(sqlq, dbzone.ZoneType, dbzone.FSMMode, dbzone.Name)
+	_, err := tx.Exec(sqlq, dbzone.ZoneType, dbzone.FSMMode, dbzone.Name)
 	if CheckSQLError("UpdateZone", sqlq, err, false) {
 		return "", err
 	}
@@ -107,12 +107,12 @@ func (mdb *MusicDB) DeleteZone(tx *sql.Tx, z *Zone) (string, error) {
 	}
 
 //	var tx *sql.Tx
-	localtx, tx, err := mdb.StartTransaction(tx)
-	if err != nil {
-		log.Printf("DeleteZone: Error from mdb.StartTransaction(): %v\n", err)
-		return fmt.Sprintf("DeleteZone: Error creating transaction"), err
-	}
-	defer mdb.CloseTransaction(localtx, tx, err)
+//	localtx, tx, err := mdb.StartTransaction(tx)
+//	if err != nil {
+//		log.Printf("DeleteZone: Error from mdb.StartTransaction(): %v\n", err)
+//		return fmt.Sprintf("DeleteZone: Error creating transaction"), err
+//	}
+//	defer mdb.CloseTransaction(localtx, tx, err)
 
 	sg := z.SignerGroup()
 	if sg != nil {
@@ -123,7 +123,7 @@ func (mdb *MusicDB) DeleteZone(tx *sql.Tx, z *Zone) (string, error) {
 		}
 	}
 
-	_, err = tx.Exec("DELETE FROM zones WHERE name=?", z.Name)
+	_, err := tx.Exec("DELETE FROM zones WHERE name=?", z.Name)
 	if err != nil {
 		fmt.Printf("DeleteZone: Error from tx.Exec: %v\n", err)
 		return fmt.Sprintf("Failed to delete zone '%s'", z.Name), err

--- a/musicd/apiserver.go
+++ b/musicd/apiserver.go
@@ -243,7 +243,7 @@ func APIzone(conf *Config) func(w http.ResponseWriter, r *http.Request) {
 		} else {
 			switch zp.Command {
 			case "list":
-				zs, err := mdb.ListZones()
+				zs, err := mdb.ListZones(tx)
 				if err != nil {
 					log.Printf("Error from ListZones: %v", err)
 				}


### PR DESCRIPTION
Not ready for commit, but I'd appreciate feedback on this change.

- It removes a ton of error returns from all over the music/*ops.go code
- It is based on the observation that transactions can only be initiated by either a request via apiserver or by a mdb.PushZone() from fsmengine. So let's create the transactions there only and remove all that cruft from the rest of the code.
- Happiness is a negative diff :-)

Note that this is only briefly tested at this stage. Although the fix is simple in theory, it is quite large, so it really requires more testing.

Johan